### PR TITLE
[WIP] feat: Sqrt operator support in ONNXToTorch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,12 @@ dmypy.json
 
 # Visual Studio Code Files
 .vscode
+
+# Gnu Global
+GPATH
+GRTAGS
+GTAGS
+
+# Emacs save file
+
+\#*\#

--- a/src/Conversion/ONNXToTorch/CMakeLists.txt
+++ b/src/Conversion/ONNXToTorch/CMakeLists.txt
@@ -34,6 +34,7 @@ add_onnx_mlir_library(OMONNXToTorch
   NN/SoftmaxOp.cpp
   NN/ConcatOp.cpp
   NN/AbsOp.cpp
+  NN/SqrtOp.cpp
   #NN/CommonUtils.cpp
   #NN/Normalization.cpp
   #NN/Pooling.cpp
@@ -45,21 +46,21 @@ add_onnx_mlir_library(OMONNXToTorch
   #RNN/RNNBase.cpp
   #Tensor/ArgMax.cpp
   #Tensor/Concat.cpp
-  #Tensor/Compress.cpp  
+  #Tensor/Compress.cpp
   #Tensor/Constant.cpp
   #Tensor/ConstantOfShape.cpp
   #Tensor/DepthToSpace.cpp
   #Tensor/Expand.cpp
   #Tensor/Flatten.cpp
-  #Tensor/Gather.cpp 
+  #Tensor/Gather.cpp
   #Tensor/Identity.cpp
   #Tensor/NonZero.cpp
-  #Tensor/OneHot.cpp  
+  #Tensor/OneHot.cpp
   #Tensor/Pad.cpp
   #Tensor/Squeeze.cpp
   #Tensor/Split.cpp
   #Tensor/Shape.cpp
-  #Tensor/Size.cpp 
+  #Tensor/Size.cpp
   #Tensor/Slice.cpp
   #Tensor/SpaceToDepth.cpp
   #Tensor/Reshape.cpp
@@ -110,7 +111,7 @@ add_onnx_mlir_library(ONNXToAtenTypesTransform
 
 
 add_onnx_mlir_library(ONNXToAtenConv2DOpTransform
-  NN/Conv22DOpTransformToTorchPass.cpp 
+  NN/Conv22DOpTransformToTorchPass.cpp
 
   LINK_LIBS PUBLIC
   OMONNXOps

--- a/src/Conversion/ONNXToTorch/ConvertONNXToTorch.cpp
+++ b/src/Conversion/ONNXToTorch/ConvertONNXToTorch.cpp
@@ -42,9 +42,10 @@ void populateONNXToTorchConversionPattern(RewritePatternSet &patterns,
       patterns, typeConverter, ctx);
   populateLoweringONNXToTorchReduceMeanOpPattern(patterns, typeConverter, ctx);
   populateLoweringONNXToTorchGemmOpPattern(patterns, typeConverter, ctx);
-  populateLoweringONNXToTorchSoftmaxOpPattern (patterns, typeConverter, ctx);
-  populateLoweringONNXToTorchConcatOpPattern (patterns, typeConverter, ctx);
-  populateLoweringONNXToTorchAbsOpPattern (patterns, typeConverter, ctx);
+  populateLoweringONNXToTorchSoftmaxOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXToTorchConcatOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXToTorchAbsOpPattern(patterns, typeConverter, ctx);
+  populateLoweringONNXToTorchSqrtOpPattern(patterns, typeConverter, ctx, enableTiling);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/Conversion/ONNXToTorch/NN/SqrtOp.cpp
+++ b/src/Conversion/ONNXToTorch/NN/SqrtOp.cpp
@@ -13,34 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/Conversion/ONNXToTorch/ONNXToTorchCommon.hpp"
-#include "src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp"
-
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/Interfaces/CallInterfaces.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Support/FileUtilities.h"
-#include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/Support/MD5.h"
-#include "llvm/Support/ToolOutputFile.h"
-
-#include "src/Dialect/Krnl/KrnlOps.hpp"
-#include "src/Dialect/ONNX/ONNXOps.hpp"
-#include "src/Interface/ShapeInferenceOpInterface.hpp"
-#include "src/Pass/Passes.hpp"
-#include "src/Support/OMOptions.hpp"
-
-
-#include "mlir/Transforms/DialectConversion.h"
-#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
-#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
-#include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
-#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
-#include "llvm/ADT/StringExtras.h"
-
-#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
-#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
-#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
 
 #ifdef _WIN32
 #include <io.h>

--- a/src/Conversion/ONNXToTorch/NN/SqrtOp.cpp
+++ b/src/Conversion/ONNXToTorch/NN/SqrtOp.cpp
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===------- SqrtOp.cpp - ONNX Op Transform ------------------===//
+//
+// Copyright 2022, Helprack LLC.
+//
+// =============================================================================
+//
+// This file lowers Sqrt op from Onnx to torch
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Conversion/ONNXToTorch/ONNXToTorchCommon.hpp"
+#include "src/Dialect/ONNX/ShapeInference/ONNXShapeHelper.hpp"
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/FileUtilities.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Support/MD5.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+#include "src/Dialect/Krnl/KrnlOps.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Interface/ShapeInferenceOpInterface.hpp"
+#include "src/Pass/Passes.hpp"
+#include "src/Support/OMOptions.hpp"
+
+
+#include "mlir/Transforms/DialectConversion.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
+#include "torch-mlir/Dialect/Torch/Transforms/Passes.h"
+#include "torch-mlir/Dialect/Torch/Utils/Utils.h"
+#include "llvm/ADT/StringExtras.h"
+
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/Transforms/BackendTypeConversion.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionOps.h"
+
+#ifdef _WIN32
+#include <io.h>
+#endif
+
+/*
+# ONNX Sqrt operation
+
+Square root takes one input data (Tensor) and produces one output data (Tensor) where the square root is, y = x^0.5, is applied to the tensor elementwise. If x is negative, then it will return NaN.
+Version
+
+This version of the operator has been available since version 13 of the default ONNX operator set.
+
+Other versions of this operator: 1, 6
+# Inputs
+
+X (differentiable) : T
+    Input tensor
+
+# Outputs
+
+Y (differentiable) : T
+    Output tensor
+
+# Type Constraints
+
+T : tensor(float16), tensor(float), tensor(double), tensor(bfloat16)
+    Constrain input and output types to float tensors.
+*/
+
+using namespace mlir;
+using namespace mlir::torch;
+using namespace mlir::torch::Torch;
+
+class ONNXSqrtOpToTorchLowering : public ConversionPattern {
+public:
+  ONNXSqrtOpToTorchLowering(TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(
+            typeConverter, mlir::ONNXSqrtOp::getOperationName(), 1, ctx) {}
+
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const final {
+    ONNXSqrtOp sqrtOp = llvm::dyn_cast_or_null<ONNXSqrtOp>(op);
+
+    assert(sqrtOp && "Expecting op to have type ONNXSqrt");
+
+    Location loc = sqrtOp.getLoc();
+    Value x = sqrtOp.X();
+    mlir::MLIRContext *context =  sqrtOp.getContext();
+
+    TensorType x_tensor_type = x.getType().cast<TensorType>();
+    TensorType op_tensor_type = sqrtOp.getResult().getType().cast<TensorType>();
+
+    auto xTy = Torch::ValueTensorType::get(context,
+                                           x_tensor_type.getShape(),
+                                           x_tensor_type.getElementType());
+    auto xtt = rewriter.create<torch::TorchConversion::FromBuiltinTensorOp>(
+        loc, xTy, x);
+
+    auto resultTy = Torch::ValueTensorType::get(context,
+                                                op_tensor_type.getShape(),
+                                                op_tensor_type.getElementType());
+
+    llvm::outs() << "Sqrt input is "
+                 << xtt << "\n"
+                 << "\n";
+
+    // y = x^0.5
+    Value atenSqrt = rewriter.create<AtenSqrtOp>(loc, resultTy, xtt);
+
+    llvm::outs() << "ATENSqrt CREATED is "
+                 << atenSqrt << "\n"
+                 << "\n";
+
+    Value result = atenSqrt;
+
+    rewriter.replaceOpWithNewOp<TensorStaticInfoCastOp>(op, resultTy, result);
+
+    return success();
+  }
+};
+
+void populateLoweringONNXToTorchSqrtOpPattern(
+    RewritePatternSet &patterns,
+    TypeConverter &typeConverter,
+    MLIRContext *ctx,
+    bool enableTiling
+) {
+    patterns.insert<ONNXSqrtOpToTorchLowering>(typeConverter, ctx);
+}

--- a/src/Conversion/ONNXToTorch/ONNXToTorchCommon.hpp
+++ b/src/Conversion/ONNXToTorch/ONNXToTorchCommon.hpp
@@ -148,3 +148,6 @@ void populateLoweringONNXToTorchConcatOpPattern(
 
 void populateLoweringONNXToTorchAbsOpPattern(
     RewritePatternSet &, TypeConverter &, MLIRContext *);
+
+void populateLoweringONNXToTorchSqrtOpPattern(
+    RewritePatternSet &, TypeConverter &, MLIRContext *, bool enableTiling);


### PR DESCRIPTION
# Add
+ Support for new `Sqrt` op in ONNXToTorch
+ `.gitignore` for Gnu Global and Emacs save files.

# changed
+ removed trailing whitespace for all the changed files.

# Pending:
+ Testing