### PR TITLE
allow for conv2d with implicit group

### DIFF
--- a/src/Conversion/ONNXToTorch/NN/Conv2D.cpp
+++ b/src/Conversion/ONNXToTorch/NN/Conv2D.cpp
@@ -76,18 +76,19 @@ struct ONNXConvOpToTorchLowering : public ConversionPattern {
 
     // create vector of tensor list iterate through the ArrayAttribute
     // list.
+    auto sintType = IntegerType::get(op1.getContext(), 64, IntegerType::SignednessSemantics::Signed);
     std::vector<Value> translatepadsList =
-        createPadsArrayAttribute(pads, group.getType(), loc, rewriter);
+        createPadsArrayAttribute(pads, sintType, loc, rewriter);
     std::vector<Value> dilationonnxList =
-        createArrayAttribute(dilations, group.getType(), loc, rewriter, 1);
+        createArrayAttribute(dilations, sintType, loc, rewriter, 1);
     std::vector<Value> kernalshapeonnxList =
-        createArrayAttribute(kernal_shape, group.getType(), loc, rewriter);
+        createArrayAttribute(kernal_shape, sintType, loc, rewriter);
     std::vector<Value> stridesonnxList =
-        createArrayAttribute(strides, group.getType(), loc, rewriter);
+        createArrayAttribute(strides, sintType, loc, rewriter);
 
     // If group Value is null, assigning default value.
-    auto zero = 0;
     auto intType = IntegerType::get(op1.getContext(), 64);
+    auto zero = 0;
     auto zeroAttr = IntegerAttr::get(intType, zero);
     Value zeroConstOp = rewriter.create<ConstantIntOp>(loc, zeroAttr);
     Value oneConstOp;
@@ -96,8 +97,9 @@ struct ONNXConvOpToTorchLowering : public ConversionPattern {
       oneConstOp = rewriter.create<ConstantIntOp>(loc, group);
       groupVal = rewriter.create<ConstantIntOp>(loc, group);
     } else {
-      oneConstOp = rewriter.create<ConstantIntOp>(loc, zeroConstOp);
-      groupVal = rewriter.create<ConstantIntOp>(loc, zeroConstOp);
+      auto oneAttr = IntegerAttr::get(sintType, 1);
+      oneConstOp = rewriter.create<ConstantIntOp>(loc, oneAttr);
+      groupVal = rewriter.create<ConstantIntOp>(loc, oneAttr);
     }
 
     // create the Torch List type using above created vectors.

--- a/src/Conversion/ONNXToTorch/NN/Conv2D.cpp
+++ b/src/Conversion/ONNXToTorch/NN/Conv2D.cpp
@@ -87,19 +87,15 @@ struct ONNXConvOpToTorchLowering : public ConversionPattern {
         createArrayAttribute(strides, sintType, loc, rewriter);
 
     // If group Value is null, assigning default value.
-    auto intType = IntegerType::get(op1.getContext(), 64);
-    auto zero = 0;
-    auto zeroAttr = IntegerAttr::get(intType, zero);
-    Value zeroConstOp = rewriter.create<ConstantIntOp>(loc, zeroAttr);
-    Value oneConstOp;
-    Value groupVal;
+    Value groupTorchInt;
     if (group) {
-      oneConstOp = rewriter.create<ConstantIntOp>(loc, group);
-      groupVal = rewriter.create<ConstantIntOp>(loc, group);
+      groupTorchInt = rewriter.create<ConstantIntOp>(loc, group);
     } else {
+      // NOTE: we would like if inferShapes() had filled in default values
+      // so we could assume `group` is always set, but currently inferShapes()
+      // does not do this for ConvOp (it does for ConvTransposeOp).
       auto oneAttr = IntegerAttr::get(sintType, 1);
-      oneConstOp = rewriter.create<ConstantIntOp>(loc, oneAttr);
-      groupVal = rewriter.create<ConstantIntOp>(loc, oneAttr);
+      groupTorchInt = rewriter.create<ConstantIntOp>(loc, oneAttr);
     }
 
     // create the Torch List type using above created vectors.
@@ -114,10 +110,6 @@ struct ONNXConvOpToTorchLowering : public ConversionPattern {
     Value padsList = rewriter.create<PrimListConstructOp>(loc,
         Torch::ListType::get(rewriter.getType<Torch::IntType>()),
         ValueRange{translatepadsList});
-
-    Value kernalShapeList = rewriter.create<PrimListConstructOp>(loc,
-        Torch::ListType::get(rewriter.getType<Torch::IntType>()),
-        ValueRange{kernalshapeonnxList});
 
     // create a tensor types using onnx operands.
     TensorType xTensorType = x.getType().cast<TensorType>();
@@ -152,7 +144,7 @@ struct ONNXConvOpToTorchLowering : public ConversionPattern {
     // emit the Conv2d operation in Torch side using "AtenConv2dOp".
     Value result = rewriter.create<AtenConv2dOp>(loc, resultType, xTorchTensor,
         wTorchTensor, bTorchTensor, stridesList, padsList, dilationList,
-        oneConstOp);
+        groupTorchInt);
 
     rewriter.replaceOpWithNewOp<torch::TorchConversion::ToBuiltinTensorOp>(
         op, op->getResult(0).getType(), result);

--- a/test/mlir/conversion/onnx_to_torch/conv2d/nogroup_conv2d.onnx.mlir
+++ b/test/mlir/conversion/onnx_to_torch/conv2d/nogroup_conv2d.onnx.mlir
@@ -1,0 +1,16 @@
+//RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
+
+module {
+  func @main_graph(%arg0: tensor<20x16x50x40xf32>) -> tensor<20x13x48x38xf32> attributes {input_names = ["0"], output_names = ["2"]} {
+    %0 = "onnx.Constant"() {value = dense<0.0> : tensor<13x16x3x3xf32>} : () -> tensor<13x16x3x3xf32>
+    %1 = "onnx.NoValue"() {value} : () -> none
+//CHECK: %[[DIM:.*]] = torch.constant.int 0
+//CHECK: %[[DIM1:.*]] = torch.constant.int 1
+//CHECK: [[STRIDE:%.]] = torch.prim.ListConstruct %[[DIM1]], %[[DIM1]] : (!torch.int, !torch.int) -> !torch.list<int>
+//CHECK: [[PAD:%.]] = torch.prim.ListConstruct %[[DIM]], %[[DIM]] : (!torch.int, !torch.int) -> !torch.list<int>
+//CHECK: %[[NONE:.*]] = torch.constant.none
+//CHECK: torch.aten.conv2d %arg0, %{{[^,]*}}, %none, [[STRIDE]], [[PAD]], [[STRIDE]], %[[DIM1]] : !torch.vtensor<[20,16,50,40],f32>, !torch.vtensor<[13,16,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int -> !torch.vtensor<[20,13,48,38],f32>
+    %2 = "onnx.Conv"(%arg0, %0, %1) {dilations = [1, 1], kernel_shape = [3, 3], pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<20x16x50x40xf32>, tensor<13x16x3x3xf32>, none) -> tensor<20x13x48x38xf32>
+    return %2 : tensor<20x13x48x38xf32>
+  }
+}


### PR DESCRIPTION
The conversion assumed that `group` would be specified, but it can be implicit in which case we need to create the required type and value.