### PR TITLE
chore: do not blindly ignore auto_pad

### DIFF
--- a/src/Conversion/ONNXToTorch/NN/Conv2D.cpp
+++ b/src/Conversion/ONNXToTorch/NN/Conv2D.cpp
@@ -74,6 +74,12 @@ struct ONNXConvOpToTorchLowering : public ConversionPattern {
     auto pads = op1.padsAttr();                 // ::mlir::ArrayAttr
     auto strides = op1.stridesAttr();           // ::mlir::ArrayAttr
 
+    // NOTE: we would like if inferShapes() had filled in explicit padding
+    // but currently inferShapes() does not do this for ConvOp (it does for
+    // ConvTransposeOp). We have not implemented code for autopad so fail.
+    if (autopad && autopad != "NOTSET")
+      return rewriter.notifyMatchFailure(op, "padding must be explicit");
+
     // create vector of tensor list iterate through the ArrayAttribute
     // list.
     auto sintType = IntegerType::get(op1.getContext(), 64, IntegerType::SignednessSemantics::Signed);

--- a/test/mlir/conversion/onnx_to_torch/conv2d/pad_notset_conv2d.onnx.mlir
+++ b/test/mlir/conversion/onnx_to_torch/conv2d/pad_notset_conv2d.onnx.mlir
@@ -1,0 +1,16 @@
+//RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
+
+module {
+  func @main_graph(%arg0: tensor<20x16x50x40xf32>) -> tensor<20x13x48x38xf32> attributes {input_names = ["0"], output_names = ["2"]} {
+    %0 = "onnx.Constant"() {value = dense<0.0> : tensor<13x16x3x3xf32>} : () -> tensor<13x16x3x3xf32>
+    %1 = "onnx.NoValue"() {value} : () -> none
+//CHECK: %[[DIM:.*]] = torch.constant.int 0
+//CHECK: %[[DIM1:.*]] = torch.constant.int 1
+//CHECK: [[STRIDE:%.]] = torch.prim.ListConstruct %[[DIM1]], %[[DIM1]] : (!torch.int, !torch.int) -> !torch.list<int>
+//CHECK: [[PAD:%.]] = torch.prim.ListConstruct %[[DIM]], %[[DIM]] : (!torch.int, !torch.int) -> !torch.list<int>
+//CHECK: %[[NONE:.*]] = torch.constant.none
+//CHECK: torch.aten.conv2d %arg0, %{{[^,]*}}, %none, [[STRIDE]], [[PAD]], [[STRIDE]], %[[DIM1]] : !torch.vtensor<[20,16,50,40],f32>, !torch.vtensor<[13,16,3,3],f32>, !torch.none, !torch.list<int>, !torch.list<int>, !torch.list<int>, !torch.int -> !torch.vtensor<[20,13,48,38],f32>
+    %2 = "onnx.Conv"(%arg0, %0, %1) {dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], auto_pad = "NOTSET", pads = [0, 0, 0, 0], strides = [1, 1]} : (tensor<20x16x50x40xf32>, tensor<13x16x3x3xf32>, none) -> tensor<20x13x48x38xf32>
+    return %2 : tensor<20x13x48x38xf32>
+  }
+}

--- a/test/mlir/conversion/onnx_to_torch/conv2d/pad_valid_conv2d.onnx.mlir
+++ b/test/mlir/conversion/onnx_to_torch/conv2d/pad_valid_conv2d.onnx.mlir
@@ -1,0 +1,15 @@
+//RUN: not onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t 2>&1 | FileCheck -v %s
+//
+//auto_pad values other than NOTSET are not currently supported, so check we fail. When
+//support is added, this can be changed to check the padding is correctly set to zero.
+//
+//CHECK: failed to legalize operation 'onnx.Conv'
+
+module {
+  func @main_graph(%arg0: tensor<20x16x50x40xf32>) -> tensor<20x13x48x38xf32> attributes {input_names = ["0"], output_names = ["2"]} {
+    %0 = "onnx.Constant"() {value = dense<0.0> : tensor<13x16x3x3xf32>} : () -> tensor<13x16x3x3xf32>
+    %1 = "onnx.NoValue"() {value} : () -> none
+    %2 = "onnx.Conv"(%arg0, %0, %1) {dilations = [1, 1], group = 1 : si64, kernel_shape = [3, 3], auto_pad = "VALID", strides = [1, 1]} : (tensor<20x16x50x40xf32>, tensor<13x16x3x3xf32>, none) -> tensor<20x13x48x38xf32>
+    return %2 : tensor<20x13x48x38xf32>
+  }
+}


### PR DESCRIPTION
If we do not support some part of an operation, then we should fail gracefully.