### PR TITLE
Fix ReduceMean + GlobalAveragePool

### DIFF
--- a/src/Conversion/ONNXToTorch/NN/ReduceMean.cpp
+++ b/src/Conversion/ONNXToTorch/NN/ReduceMean.cpp
@@ -19,11 +19,11 @@
 /*
  * ONNX ReduceMean operation
  *
- * “Computes the mean of the input tensor’s element along the provided axes.
+ * Computes the mean of the input tensor’s element along the provided axes.
  * The resulted” “tensor has the same rank as the input if keepdims equal 1.
  * If keepdims equal 0, then” “the resulted tensor have the reduced
- * dimension pruned.” “” “The above behavior is similar to numpy, with the
- * exception that numpy default keepdims to” “False instead of True.”
+ * dimension pruned. The above behavior is similar to numpy, with the
+ * exception that numpy default keepdims to” “False instead of True.
  *
  * Attributes:
  *   axes	::mlir::ArrayAttr	64-bit integer array attribute
@@ -60,27 +60,30 @@ public:
     ONNXReduceMeanOp reduceMean = llvm::dyn_cast_or_null<ONNXReduceMeanOp>(op);
     assert(reduceMean && "Expecting op to have a strong type");
 
-    // **TODO**: reduceMean.axes is not being used currently. Probably use
-    // AtenMeanDimOp instead of AtenMean, or use both.
-
     mlir::MLIRContext *context = reduceMean.getContext();
     Location loc = reduceMean.getLoc();
 
     auto axis = mlir::extractFromI64ArrayAttr(reduceMean.axesAttr());
     if(!(axis.size() == 2 && axis[0] == 2 && axis[1] == 3))
-      op->emitError("Not implemented yet for general axis sizes");
+      assert("Not implemented yet for general axis sizes");
 
     auto keepDims = reduceMean.keepdimsAttr(); // ::mlir::IntegerAttr
+    auto keepDimsVal = rewriter.create<ConstantBoolOp>(loc, true);
 
-    Value keepdimVal = (keepDims)
-                           ? rewriter.create<ConstantIntOp>(loc, keepDims)
-                           : getIntValue(0, rewriter, context, loc);
 
     auto dataTensor = getTorchTensor(reduceMean.data(), rewriter, context, loc);
     auto resultType = toTorchType(context, reduceMean.getResult().getType());
 
-    Value result =
-        rewriter.create<AtenMeanOp>(loc, resultType, dataTensor, keepdimVal);
+
+    auto sintType = IntegerType::get(getContext(), 64, IntegerType::SignednessSemantics::Signed);
+    std::vector<Value> axisVal =
+        createArrayAttribute(reduceMean.axesAttr(), sintType, loc, rewriter, 1);
+    Value axisList = rewriter.create<PrimListConstructOp>(loc,
+        Torch::ListType::get(rewriter.getType<Torch::IntType>()),
+        ValueRange{axisVal});
+    
+    Value dtype = rewriter.create<ConstantNoneOp>(loc);
+    Value result = rewriter.create<AtenMeanDimOp>(loc, resultType, dataTensor, axisList, keepDimsVal, dtype);
 
     rewriter.replaceOpWithNewOp<torch::TorchConversion::ToBuiltinTensorOp>(
         op, op->getResult(0).getType(), result);

--- a/test/mlir/conversion/onnx_to_torch/global_avg_pool/global_avg_pool.onnx.mlir
+++ b/test/mlir/conversion/onnx_to_torch/global_avg_pool/global_avg_pool.onnx.mlir
@@ -1,10 +1,10 @@
-//RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
+// RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
 module attributes {}  {
   func @main_graph(%arg0: tensor<1x3x4x4xf32>) -> tensor<1x3x1x1xf32> attributes {input_names = ["input"], output_names = ["1"]} {
-//CHECK: %[[CONST:.*]] = torch.constant.int 0
-// this gets canonicalized to an onnx.ReduceMean
+// `onnx.GlobalAveragePool` gets canonicalized to `onnx.ReduceMean`
+// CHECK: %[[AXIS:.*]] = torch.prim.ListConstruct %int2, %int3 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK: %[[MEAN:.*]] = torch.aten.mean.dim %arg0, %[[AXIS]], %true, %none : !torch.vtensor<[1,3,4,4],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[1,3,1,1],f32>
     %0 = "onnx.GlobalAveragePool"(%arg0) : (tensor<1x3x4x4xf32>) -> tensor<1x3x1x1xf32>
-//CHECK: torch.aten.mean %arg0, %[[CONST]] : !torch.vtensor<[1,3,4,4],f32>, !torch.int -> !torch.vtensor<[1,3,1,1],f32>
     return %0 : tensor<1x3x1x1xf32>
   }
 }

--- a/test/mlir/conversion/onnx_to_torch/reduce_mean/reduce_mean.onnx.mlir
+++ b/test/mlir/conversion/onnx_to_torch/reduce_mean/reduce_mean.onnx.mlir
@@ -1,9 +1,9 @@
-//RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
+// RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
 module attributes {}  {
   func @main_graph(%arg0: tensor<2x5x9x11xf32>) -> tensor<2x5x1x1xf32> attributes {input_names = ["input"], output_names = ["1"]} {
-//CHECK: %[[CONST:.*]] = torch.constant.int 0
+// CHECK: %[[AXIS:.*]] = torch.prim.ListConstruct %int2, %int3 : (!torch.int, !torch.int) -> !torch.list<int>
+// CHECK: %[[MEAN:.*]] = torch.aten.mean.dim %arg0, %[[AXIS]], %true, %none : !torch.vtensor<[2,5,9,11],f32>, !torch.list<int>, !torch.bool, !torch.none -> !torch.vtensor<[2,5,1,1],f32>
     %0 = "onnx.ReduceMean"(%arg0) {axes = [2, 3]} : (tensor<2x5x9x11xf32>) -> tensor<2x5x1x1xf32>
-//CHECK: torch.aten.mean %arg0, %[[CONST]] : !torch.vtensor<[2,5,9,11],f32>, !torch.int -> !torch.vtensor<[2,5,1,1],f32>
     return %0 : tensor<2x5x1x1xf32>
   }
 }


### PR DESCRIPTION
* `matchAndReplace` with appropriate `aten.mean.dim` op