### PR TITLE
[TOSA] Refactor type converter and unary ops

### DIFF
--- a/src/Conversion/ONNXToTOSA/CMakeLists.txt
+++ b/src/Conversion/ONNXToTOSA/CMakeLists.txt
@@ -2,6 +2,9 @@
 
 add_onnx_mlir_library(OMONNXToTOSA
   ConvertONNXToTOSA.cpp
+
+  Math/Elementwise.cpp
+
   LINK_LIBS PUBLIC
   OMONNXOps
   MLIRTosa

--- a/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Elementwise.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------------- Elementwise.cpp - Elementwise Op --------------------===//
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file lowers ONNX element-wise operators to TOSA dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+namespace {
+
+template <typename ONNXOpT, typename TOSAOpT>
+class ONNXUnaryOpLoweringToTOSA : public OpConversionPattern<ONNXOpT> {
+public:
+  using OpConversionPattern<ONNXOpT>::OpConversionPattern;
+  using OpAdaptor = typename ONNXOpT::Adaptor;
+  LogicalResult matchAndRewrite(ONNXOpT op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<TOSAOpT>(op, op.getType(), adaptor.X());
+    return success();
+  }
+};
+
+class ONNXReluOpLoweringToTOSA : public OpConversionPattern<ONNXReluOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(ONNXReluOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+
+    // Rescale the input for quantized types. TBD
+    // Maps to tosa.clamp which has both int and fp limits.
+    Value input = adaptor.X();
+
+    rewriter.replaceOpWithNewOp<tosa::ClampOp>(op, op.getType(), input,
+        rewriter.getI64IntegerAttr(0),
+        rewriter.getI64IntegerAttr(std::numeric_limits<int32_t>::max()),
+        rewriter.getF32FloatAttr(0.0f),
+        rewriter.getF32FloatAttr(std::numeric_limits<float>::max()));
+    return success();
+  }
+};
+
+} // namespace
+
+void populateLoweringONNXElementwiseOpToTOSAPattern(RewritePatternSet &patterns,
+    TypeConverter &typeConverter, MLIRContext *ctx) {
+  patterns.insert<ONNXReluOpLoweringToTOSA>(typeConverter, ctx);
+
+#define INSERT_UNARY_PATTERN(ONNXOp, TOSAOp)                                   \
+  patterns.insert<ONNXUnaryOpLoweringToTOSA<ONNXOp, TOSAOp>>(                  \
+      typeConverter, ctx);
+  INSERT_UNARY_PATTERN(ONNXNegOp, tosa::NegateOp)
+  INSERT_UNARY_PATTERN(ONNXFloorOp, tosa::FloorOp)
+#undef INSERT_UNARY_PATTERN
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//====------ ONNXToTOSACommon.hpp - ONNX dialects to TOSA lowering --------===//
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file contains common code shared by the functions performing the
+// lowering to the TOSA dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "src/Dialect/ONNX/DialectBuilder.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "src/Dialect/ONNX/ONNXOpsHelper.hpp"
+#include "src/Pass/Passes.hpp"
+#include "src/Transform/ONNX/ConstPropHelper.hpp"
+
+//===----------------------------------------------------------------------===//
+// Functions to add lowering patterns for frontend operations.
+//===----------------------------------------------------------------------===//
+
+namespace onnx_mlir {
+
+//===----------------------------------------------------------------------===//
+// This is to get a TOSA operation of a given type for a specific operation.
+//===----------------------------------------------------------------------===//
+template <typename ONNXOp>
+struct TOSADialectOp {
+  using Op = void;
+};
+
+template <typename Op>
+using TOSAOp = typename TOSADialectOp<Op>::Op;
+
+// `Math` directory methods:
+void populateLoweringONNXElementwiseOpToTOSAPattern(
+    RewritePatternSet &, TypeConverter &, MLIRContext *);
+} // namespace onnx_mlir

--- a/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Elementwise.mlir
@@ -1,0 +1,37 @@
+// RUN: onnx-mlir-opt --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
+
+func.func @test_relu(%arg0 : tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %0 = "onnx.Relu"(%arg0) : (tensor<10x10xf32>) -> tensor<10x10xf32>
+  "func.return"(%0) : (tensor<10x10xf32>) -> ()
+// CHECK-LABEL:  func @test_relu
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x10xf32>) -> tensor<10x10xf32> {
+// CHECK-NEXT:      [[VAR_0_:%.+]] = "tosa.clamp"(%arg0) {max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<10x10xf32>) -> tensor<10x10xf32>
+// CHECK-NEXT:      return [[VAR_0_]] : tensor<10x10xf32>
+// CHECK-NEXT:    }
+}
+
+func.func @test_relu_dynamic(%arg0 : tensor<?x10xf32>) -> tensor<?x10xf32> {
+  %0 = "onnx.Relu"(%arg0) : (tensor<?x10xf32>) -> tensor<?x10xf32>
+  "func.return"(%0) : (tensor<?x10xf32>) -> ()
+// CHECK-LABEL:  func @test_relu_dynamic
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x10xf32>) -> tensor<?x10xf32> {
+// CHECK-NEXT:      [[VAR_0_:%.+]] =  "tosa.clamp"(%arg0) {max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64} : (tensor<?x10xf32>) -> tensor<?x10xf32>
+// CHECK-NEXT:      return [[VAR_0_]] : tensor<?x10xf32>
+// CHECK-NEXT:    }
+}
+
+func.func @test_neg(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %0 = "onnx.Neg"(%arg0) : (tensor<10x10xf32>) -> tensor<10x10xf32>
+  "func.return"(%0) : (tensor<10x10xf32>) -> ()
+// CHECK-LABEL:  func @test_neg
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x10xf32>) -> tensor<10x10xf32> {
+// CHECK-NEXT:      [[VAR_0_:%.+]] = "tosa.negate"([[PARAM_0_]]) : (tensor<10x10xf32>) -> tensor<10x10xf32>
+}
+
+func.func @test_floor(%arg0: tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %0 = "onnx.Floor"(%arg0) : (tensor<10x10xf32>) -> tensor<10x10xf32>
+  "func.return"(%0) : (tensor<10x10xf32>) -> ()
+// CHECK-LABEL:  func @test_floor
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<10x10xf32>) -> tensor<10x10xf32> {
+// CHECK-NEXT:      [[VAR_0_:%.+]] = "tosa.floor"([[PARAM_0_]]) : (tensor<10x10xf32>) -> tensor<10x10xf32>
+}


### PR DESCRIPTION
* Updates type converter to only legalize valid TOSA types
* Restructures `ONNXToTOSA` pass to allign with `Mhlo`
* LIT tests for unary ops
* Support for `onnx.Floor` and `onnx.Neg`