### PR TITLE
FXML-638: Conversion ONNX GEMM to Linear 

### DIFF
--- a/src/Conversion/ONNXToTorch/NN/Gemm.cpp
+++ b/src/Conversion/ONNXToTorch/NN/Gemm.cpp
@@ -93,6 +93,33 @@ public:
     return transposedShape;
   }
 
+  /// Creates a tensor literal in torch using a f32 element type given
+  /// a float constant.
+  /// The bias is assumed to be 1 dimensional as that is the rank that is
+  /// accepted by the torch.aten.linear operator. The size of the dimension
+  /// is taken from the trailing dimensions of the op return result type
+  static Value createLiteralTensor(ONNXGemmOp &op,
+      ConversionPatternRewriter &rewriter, TypeConverter &typeConverter,
+      float constant) {
+    // We need to get the shape of the return type from the original result
+    auto originalResultOpType = op->getResult(0).getType().cast<TensorType>();
+
+    // Create a dense constant type tensor with the given value. Have the single
+    // dimension be the size of the trailing dimension of the return type
+    auto denseElementType = ::mlir::FloatType::getF32(rewriter.getContext());
+    ShapedType denseValueType =
+        RankedTensorType::get(originalResultOpType.getShape().drop_front(
+                                  originalResultOpType.getRank() - 1),
+            denseElementType);
+    auto denseAttr = DenseElementsAttr::get(denseValueType, constant);
+
+    // Convert the tensor type to the torch equivalent
+    auto torchTensorType =
+        typeConverter.convertType(denseValueType.cast<Type>());
+    return rewriter.create<Torch::ValueTensorLiteralOp>(
+        op.getLoc(), torchTensorType, denseAttr);
+  }
+
   LogicalResult rewriteToAtenLinear(ONNXGemmOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const {
     Value A = adaptor.A();
@@ -100,6 +127,13 @@ public:
     Value C = adaptor.C();
 
     Type resultType = getTypeConverter()->convertType(op.getResult().getType());
+
+    // If no bias is given to the GEMM operator, we create a 1D bias with all
+    // zeroes
+    if (C.getType().isa<mlir::NoneType>()) {
+      C = createLiteralTensor(op, rewriter, *getTypeConverter(), 0.0F);
+    }
+
     rewriter.replaceOpWithNewOp<AtenLinearOp>(op, resultType, A, B, C);
     return success();
   }
@@ -108,7 +142,7 @@ public:
   /// Y = AB^T + C if we perform a transpose on B only with
   /// alpha and beta factors set to 1.
   /// The constraints on rank were taken from the torch implementation check
-  /// Input A must be of rank 2 or 3 (input)
+  /// Input A must be of rank 2 (input)
   /// Input B must be of rank 2 (weights)
   /// Input C must be of rank 1 (bias)
   static bool checkLegalAtenLinearOp(ONNXGemmOp op, OpAdaptor adaptor) {
@@ -124,12 +158,11 @@ public:
         C.getType().cast<RankedTensorType>().getRank() != 1) {
       return false;
     }
-    // Input tensor must be of rank 2 or 3
-    if (AType.getRank() != 2 && AType.getRank() != 3) {
-      return false;
-    }
-    // Weights must be of rank 2
-    if (BType.getRank() != 2) {
+    // Input tensor must be of rank 2
+    // onnx-mlir lowering to host only supports rank of 2
+    // torch-mlir supports 2 and 3
+    // Weights must also be of rank 2
+    if (AType.getRank() != 2 || BType.getRank() != 2) {
       return false;
     }
     // Both alpha and beta must be 1

--- a/src/Tools/onnx-mlir-opt/CMakeLists.txt
+++ b/src/Tools/onnx-mlir-opt/CMakeLists.txt
@@ -14,4 +14,6 @@ add_onnx_mlir_executable(onnx-mlir-opt
   MLIRLinalgTransforms
   MLIRMemRefTransforms
   MLIROptLib
+  TorchMLIRTorchDialect
+  TorchMLIRTorchConversionDialect
   )

--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -36,6 +36,8 @@
 #include "src/InitMLIRPasses.hpp"
 #include "src/InitOMPasses.hpp"
 #include "src/Pass/Passes.hpp"
+#include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
 
 using namespace mlir;
 using namespace onnx_mlir;
@@ -114,6 +116,8 @@ int main(int argc, char **argv) {
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::ONNXDialect>();
   registry.insert<mlir::KrnlOpsDialect>();
+  registry.insert<mlir::torch::Torch::TorchDialect>();
+  registry.insert<mlir::torch::TorchConversion::TorchConversionDialect>();
 
   // Initialize accelerators if they exist.
   onnx_mlir::accel::initAccelerators(maccel);

--- a/test/mlir/conversion/onnx_to_torch/gemm/Gemm_dense_nn_layer.mlir
+++ b/test/mlir/conversion/onnx_to_torch/gemm/Gemm_dense_nn_layer.mlir
@@ -3,7 +3,7 @@
 module attributes {}  {
   func @main_graph(%arg0: tensor<1x2048xf32>, %arg1: tensor<1000x2048xf32>, %arg2: tensor<1000xf32>) -> tensor<1x1000xf32> attributes {input_names = ["x", "fc.weight", "fc.bias"], output_names = ["y"]} {
 %0 = "onnx.Gemm"(%arg0, %arg1, %arg2) {transB = 1 : si64} : (tensor<1x2048xf32>, tensor<1000x2048xf32>, tensor<1000xf32>) -> tensor<1x1000xf32>
-// We now generate a linear instead of the a transpose, mul and add as it can 
+// We now generate a linear instead of a transpose, mul and add as it can 
 // be represented by a linear function in torch, e.g. Y = XA^T + B
 //CHECK: [[RES1:%.]] = torch.aten.linear %arg0, %arg1, %arg2 : !torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.vtensor<[1000],f32> -> !torch.vtensor<[1,1000],f32>       
 return %0 : tensor<1x1000xf32>

--- a/test/mlir/conversion/onnx_to_torch/gemm/Gemm_dense_nn_layer.mlir
+++ b/test/mlir/conversion/onnx_to_torch/gemm/Gemm_dense_nn_layer.mlir
@@ -2,11 +2,10 @@
 //RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
 module attributes {}  {
   func @main_graph(%arg0: tensor<1x2048xf32>, %arg1: tensor<1000x2048xf32>, %arg2: tensor<1000xf32>) -> tensor<1x1000xf32> attributes {input_names = ["x", "fc.weight", "fc.bias"], output_names = ["y"]} {
-    //CHECK: %[[CONST:.*]] = torch.constant.int 1
 %0 = "onnx.Gemm"(%arg0, %arg1, %arg2) {transB = 1 : si64} : (tensor<1x2048xf32>, tensor<1000x2048xf32>, tensor<1000xf32>) -> tensor<1x1000xf32>
-//CHECK: [[RES1:%.]] = torch.aten.t %arg1 : !torch.vtensor<[1000,2048],f32> -> !torch.vtensor<[2048,1000],f32>
-//CHECK: [[RES2:%.]] = torch.aten.mm %arg0, [[RES1]] : !torch.vtensor<[1,2048],f32>, !torch.vtensor<[2048,1000],f32> -> !torch.vtensor<[1,1000],f32>
-//CHECK: [[RES3:%.]] = torch.aten.add.Tensor [[RES2]], %arg2, %[[CONST]] : !torch.vtensor<[1,1000],f32>, !torch.vtensor<[1000],f32>, !torch.int -> !torch.vtensor<[1,1000],f32>       
+// We now generate a linear instead of the a transpose, mul and add as it can 
+// be represented by a linear function in torch, e.g. Y = XA^T + B
+//CHECK: [[RES1:%.]] = torch.aten.linear %arg0, %arg1, %arg2 : !torch.vtensor<[1,2048],f32>, !torch.vtensor<[1000,2048],f32>, !torch.vtensor<[1000],f32> -> !torch.vtensor<[1,1000],f32>       
 return %0 : tensor<1x1000xf32>
   }
 }

--- a/test/mlir/conversion/onnx_to_torch/gemm/Gemm_to_linear_optional_C.mlir
+++ b/test/mlir/conversion/onnx_to_torch/gemm/Gemm_to_linear_optional_C.mlir
@@ -1,4 +1,4 @@
-//RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
+// RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
 
 // because the optional bias is not yet implemented in the upstream TorchToLinAlg pass we will instead
 // create a bias with values of 0. Our testing relies on the lowering from torch to host code and this
@@ -12,4 +12,3 @@ module attributes {}  {
 //CHECK: return %[[RES]] :  !torch.vtensor<[1,4],f32>
 return %0 : tensor<1x4xf32>
   }
-}

--- a/test/mlir/conversion/onnx_to_torch/gemm/Gemm_to_linear_optional_C.mlir
+++ b/test/mlir/conversion/onnx_to_torch/gemm/Gemm_to_linear_optional_C.mlir
@@ -1,0 +1,16 @@
+//RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
+// XFAIL: *
+// We expect this to fail as the optional bias is not yet implemented in the upstream TorchToLinAlg pass
+// We will always assume C or the bias is given. Our testing relies on the lowering from torch to host code.
+// Note, below is what a conversion would look like for linear with an optional bias tensor.
+module attributes {}  {
+  func @main_graph(%arg0: tensor<3x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<3x4xf32> attributes {input_names = ["a", "b"], output_names = ["y"]} {
+    %none = "onnx.NoValue"() {value} : () -> none
+    %0 = "onnx.Gemm"(%arg0, %arg1, %none) {transB = 1 : si64} : (tensor<3x5xf32>, tensor<4x5xf32>, none) -> tensor<3x4xf32>
+//CHECK: %[[NONE:.*]] torch.constant.none
+//CHECK: %[[OPTIONAL:.*]] = torch.derefine %none : !torch.none to !torch.optional<tensor>
+//CHECK: %[[RES1:.]] = torch.aten.linear %arg0, %arg1, %[[OPTIONAL]] : !torch.vtensor<[3,5],f32>, !torch.vtensor<[4,5],f32>, !torch.optional<tensor> -> !torch.vtensor<[3,4],f32>>       
+//CHECK: return %[[RES1]] : tensor<3x4xf32>
+return %0 : tensor<3x4xf32>
+  }
+}

--- a/test/mlir/conversion/onnx_to_torch/gemm/Gemm_to_linear_optional_C.mlir
+++ b/test/mlir/conversion/onnx_to_torch/gemm/Gemm_to_linear_optional_C.mlir
@@ -1,16 +1,15 @@
 //RUN: onnx-mlir --EmitONNXIR --run-torch-pass %s -o=%t >/dev/null && cat %t.onnx.mlir | FileCheck -v %s
-// XFAIL: *
-// We expect this to fail as the optional bias is not yet implemented in the upstream TorchToLinAlg pass
-// We will always assume C or the bias is given. Our testing relies on the lowering from torch to host code.
-// Note, below is what a conversion would look like for linear with an optional bias tensor.
+
+// because the optional bias is not yet implemented in the upstream TorchToLinAlg pass we will instead
+// create a bias with values of 0. Our testing relies on the lowering from torch to host code and this
+// will allow us to run the lowering passes.
 module attributes {}  {
-  func @main_graph(%arg0: tensor<3x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<3x4xf32> attributes {input_names = ["a", "b"], output_names = ["y"]} {
+  func @main_graph(%arg0: tensor<1x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<1x4xf32> attributes {input_names = ["a", "b"], output_names = ["y"]} {
     %none = "onnx.NoValue"() {value} : () -> none
-    %0 = "onnx.Gemm"(%arg0, %arg1, %none) {transB = 1 : si64} : (tensor<3x5xf32>, tensor<4x5xf32>, none) -> tensor<3x4xf32>
-//CHECK: %[[NONE:.*]] torch.constant.none
-//CHECK: %[[OPTIONAL:.*]] = torch.derefine %none : !torch.none to !torch.optional<tensor>
-//CHECK: %[[RES1:.]] = torch.aten.linear %arg0, %arg1, %[[OPTIONAL]] : !torch.vtensor<[3,5],f32>, !torch.vtensor<[4,5],f32>, !torch.optional<tensor> -> !torch.vtensor<[3,4],f32>>       
-//CHECK: return %[[RES1]] : tensor<3x4xf32>
-return %0 : tensor<3x4xf32>
+    %0 = "onnx.Gemm"(%arg0, %arg1, %none) {transB = 1 : si64} : (tensor<1x5xf32>, tensor<4x5xf32>, none) -> tensor<1x4xf32>
+//CHECK: %[[CONSTANT:.*]] = torch.vtensor.literal(dense<0.000000e+00> : tensor<4xf32>) : !torch.vtensor<[4],f32>
+//CHECK: %[[RES:.*]] = torch.aten.linear %arg0, %arg1, %[[CONSTANT]] : !torch.vtensor<[1,5],f32>, !torch.vtensor<[4,5],f32>, !torch.vtensor<[4],f32> -> !torch.vtensor<[1,4],f32>
+//CHECK: return %[[RES]] :  !torch.vtensor<[1,4],f32>
+return %0 : tensor<1x4xf32>
   }
 }


### PR DESCRIPTION
A GEMM operation can be represented as a linear operation in torch under specific conditions.

`
Y=alpha*A^T * B^T + beta*C
`

If alpha and beta are equal to `1.0` and only B is transposed then we get the following:

`
Y=A*B^T+C
`

Which corresponds to the linear function in torch. 
