### PR TITLE
Max.fxml 1166.convert conv to tosa

### DIFF
--- a/src/Conversion/ONNXToTOSA/CMakeLists.txt
+++ b/src/Conversion/ONNXToTOSA/CMakeLists.txt
@@ -5,6 +5,7 @@ add_onnx_mlir_library(OMONNXToTOSA
   ONNXToTOSALegalizeUtils.cpp
 
   Math/Elementwise.cpp
+  Math/Conv2D.cpp
   Tensor/Constant.cpp
 
   LINK_LIBS PUBLIC

--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -28,6 +28,8 @@ void populateONNXToTOSAConversionPattern(ConversionTarget &target,
 
   populateLoweringONNXConstOpToTOSAPattern(
       target, patterns, typeConverter, ctx);
+
+  populateLoweringONNXConvOpToTOSAPattern(target, patterns, typeConverter, ctx);
 }
 
 // Performs lowering to TOSA dialect

--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -20,6 +20,8 @@
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/TypeUtilities.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
@@ -42,18 +44,13 @@ public:
     auto weights = adaptor.W();
     auto bias = adaptor.B();
 
-    auto inputType = input.getType().cast<ShapedType>();
     auto weightType = weights.getType().cast<ShapedType>();
 
-    auto inputShape = inputType.getShape();
     auto weightShape = weightType.getShape();
-
-    bool biasIsNone = bias.getType().isa<mlir::NoneType>();
 
     StringAttr autopad = adaptor.auto_padAttr();
     ArrayAttr dilations = adaptor.dilationsAttr();
     IntegerAttr group = adaptor.groupAttr();
-    ArrayAttr kernel_shape = adaptor.kernel_shapeAttr();
     ArrayAttr pads = adaptor.padsAttr();
     ArrayAttr strides = adaptor.stridesAttr();
 
@@ -71,109 +68,46 @@ public:
       return op.emitError("padding must be explicit");
 
     // Convert input [N,C,H,W] -> [N,H,W,C]
-    // Create permutation const for input
-    SmallVector<int64_t> permVector{0, 2, 3, 1};
-    DenseElementsAttr permAttr = DenseIntElementsAttr::get(
-        RankedTensorType::get({4}, rewriter.getI64Type()), permVector);
-    Value permList = tosa::CreateOpAndInfer<tosa::ConstOp>(
-        rewriter, op->getLoc(), permAttr.getType(), permAttr);
-
-    // calculate new shape
-    SmallVector<int64_t> newInputShape{
-        inputShape[0], inputShape[2], inputShape[3], inputShape[1]};
-
-    // get new input type
-    Type newInputTy =
-        RankedTensorType::get({-1, -1, -1, -1}, inputType.getElementType());
-
-    // create transpose for input
-    Value newInput = tosa::CreateOpAndInfer<tosa::TransposeOp>(
-        rewriter, op->getLoc(), newInputTy, input, permList);
+    Value newInput =
+        tosa::createTosaTransposedTensor(rewriter, op, input, {0, 2, 3, 1});
 
     // Convert weights [M,C,H,W] -> [M,H,W,C]
-    // Create permutation const for input
-    SmallVector<int64_t> permWeightVector{0, 2, 3, 1};
-    DenseElementsAttr permWeightAttr = DenseIntElementsAttr::get(
-        RankedTensorType::get({4}, rewriter.getI64Type()), permWeightVector);
-    Value permWeightList = tosa::CreateOpAndInfer<tosa::ConstOp>(
-        rewriter, op->getLoc(), permWeightAttr.getType(), permWeightAttr);
+    Value newWeight =
+        tosa::createTosaTransposedTensor(rewriter, op, weights, {0, 2, 3, 1});
 
-    // calculate new shape
-    SmallVector<int64_t, 4> newWeightShape{
-        weightShape[0], weightShape[2], weightShape[3], weightShape[1]};
-
-    // get new weight type
-    Type newWeightTy =
-        RankedTensorType::get({-1, -1, -1, -1}, weightType.getElementType());
-
-    // create transpose for weight
-    Value newWeight = tosa::CreateOpAndInfer<tosa::TransposeOp>(
-        rewriter, op->getLoc(), newWeightTy, weights, permWeightList);
-
-    Value newBias = NULL;
     if (bias.getType().isa<NoneType>()) {
       DenseElementsAttr newBiasAttr = DenseElementsAttr::get(
           RankedTensorType::get({weightShape[0]}, rewriter.getF32Type()),
           {0.0F});
-      newBias = rewriter.create<tosa::ConstOp>(
+      bias = rewriter.create<tosa::ConstOp>(
           op->getLoc(), newBiasAttr.getType(), newBiasAttr);
-    } else {
-      newBias = bias;
     }
-
-    ArrayAttr newDilations = NULL;
     if (!dilations) {
-      newDilations = rewriter.getI64ArrayAttr({1, 1});
-    } else {
-      newDilations = dilations;
+      dilations = rewriter.getI64ArrayAttr({1, 1});
     }
-
-    ArrayAttr newStrides = NULL;
     if (!strides) {
-      newStrides = rewriter.getI64ArrayAttr({1, 1});
-    } else {
-      newStrides = strides;
+      strides = rewriter.getI64ArrayAttr({1, 1});
     }
-    ArrayAttr newPads = NULL;
     if (!pads) {
-      newPads = rewriter.getI64ArrayAttr({0, 0, 0, 0});
+      pads = rewriter.getI64ArrayAttr({0, 0, 0, 0});
     } else {
       llvm::SmallVector<int64_t, 4> newPadVec = extractFromI64ArrayAttr(pads);
-      newPads = rewriter.getI64ArrayAttr(
-          {newPadVec[0], newPadVec[2], newPadVec[3], newPadVec[1]});
+      pads = rewriter.getI64ArrayAttr(
+          {newPadVec[0], newPadVec[2], newPadVec[1], newPadVec[3]});
     }
 
-    auto oldOutputShape = resultType.cast<ShapedType>().getShape();
-    SmallVector<int64_t, 4> newOutputShape{oldOutputShape[0], oldOutputShape[2],
-        oldOutputShape[3], oldOutputShape[1]};
-    Type newOutputType = RankedTensorType::get(
+    Type newConvOutputType = RankedTensorType::get(
         {-1, -1, -1, -1}, resultType.cast<ShapedType>().getElementType());
 
     Value conv2D = tosa::CreateOpAndInfer<tosa::Conv2DOp>(rewriter,
-        op->getLoc(), newOutputType, newInput, newWeight, newBias, newPads,
-        newStrides, newDilations);
+        op->getLoc(), newConvOutputType, newInput, newWeight, bias, pads,
+        strides, dilations);
 
-    // Convert weights [M,C,H,W] -> [M,H,W,C]
-    // Create permutation const for input
-    SmallVector<int64_t> permOutputVector{0, 3, 1, 2};
-    DenseElementsAttr permOutputAttr = DenseIntElementsAttr::get(
-        RankedTensorType::get({4}, rewriter.getI64Type()), permOutputVector);
-    Value permOutputList = rewriter.create<tosa::ConstOp>(
-        op->getLoc(), permOutputAttr.getType(), permOutputAttr);
+    // Convert output [N,H,W,M] -> [N,M,H,W]
+    Value newOutput =
+        tosa::createTosaTransposedTensor(rewriter, op, conv2D, {0, 3, 1, 2});
 
-    auto outputShape = conv2D.getType().cast<ShapedType>().getShape();
-    // calculate new shape
-    SmallVector<int64_t, 4> newOutputShapeReturn{
-        outputShape[0], outputShape[3], outputShape[1], outputShape[2]};
-
-    // get new weight type
-    Type newOutputTy = RankedTensorType::get(
-        {-1, -1, -1, -1}, resultType.cast<ShapedType>().getElementType());
-
-    // create transpose for weight
-    tosa::CreateReplaceOpAndInfer<tosa::TransposeOp>(
-        rewriter, op, newOutputTy, conv2D, permOutputList);
-
+    rewriter.replaceOp(op, {newOutput});
     return success();
   }
 };

--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -13,20 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
-#include "mlir/Dialect/Utils/StaticValueUtils.h"
-#include "mlir/IR/Attributes.h"
-#include "mlir/IR/BuiltinAttributeInterfaces.h"
-#include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/BuiltinTypeInterfaces.h"
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/TypeUtilities.h"
-#include "mlir/Support/LLVM.h"
-#include "mlir/Support/LogicalResult.h"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
-#include "llvm/ADT/None.h"
-#include "llvm/ADT/SmallVector.h"
 
 using namespace mlir;
 

--- a/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
+++ b/src/Conversion/ONNXToTOSA/Math/Conv2D.cpp
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------------- Conv2D.cpp - Conv2D Op --------------------===//
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file lowers ONNX conv operator to TOSA dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+namespace {
+
+class ONNXConvOpLoweringToTOSA : public OpConversionPattern<ONNXConvOp> {
+public:
+  using OpConversionPattern<ONNXConvOp>::OpConversionPattern;
+  using OpAdaptor = typename ONNXConvOp::Adaptor;
+  LogicalResult matchAndRewrite(ONNXConvOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto input = adaptor.X();
+    auto weights = adaptor.W();
+    auto bias = adaptor.B();
+
+    auto inputType = input.getType().cast<ShapedType>();
+    auto weightType = weights.getType().cast<ShapedType>();
+
+    auto inputShape = inputType.getShape();
+    auto weightShape = weightType.getShape();
+
+    bool biasIsNone = bias.getType().isa<mlir::NoneType>();
+
+    StringAttr autopad = adaptor.auto_padAttr();
+    ArrayAttr dilations = adaptor.dilationsAttr();
+    IntegerAttr group = adaptor.groupAttr();
+    ArrayAttr kernel_shape = adaptor.kernel_shapeAttr();
+    ArrayAttr pads = adaptor.padsAttr();
+    ArrayAttr strides = adaptor.stridesAttr();
+
+    if (group.getSInt() != 1) {
+      rewriter.notifyMatchFailure(op, "ONNX Conv grouping not supported");
+    }
+
+    // NOTE: we would like if inferShapes() had filled in explicit padding
+    // but currently inferShapes() does not do this for ConvOp (it does for
+    // ConvTransposeOp). We have not implemented code for autopad so fail.
+    if (autopad && autopad != "NOTSET")
+      return op.emitError("padding must be explicit");
+
+    // Convert input [N,C,H,W] -> [N,H,W,C]
+    // Create permutation const for input
+    SmallVector<int64_t> permVector{0, 2, 3, 1};
+    DenseElementsAttr permAttr = DenseIntElementsAttr::get(
+        RankedTensorType::get({4}, rewriter.getI64Type()), permVector);
+    Value permList = rewriter.create<tosa::ConstOp>(
+        op->getLoc(), permAttr.getType(), permAttr);
+
+    // calculate new shape
+    SmallVector<int64_t> newInputShape{
+        inputShape[0], inputShape[2], inputShape[3], inputShape[1]};
+
+    // get new input type
+    Type newInputTy =
+        RankedTensorType::get(newInputShape, inputType.getElementType());
+
+    // create transpose for input
+    rewriter.create<tosa::TransposeOp>(
+        op->getLoc(), newInputTy, input, permList);
+
+    // Convert weights [M,C,H,W] -> [M,H,W,C]
+    // Create permutation const for input
+    SmallVector<int64_t> permWeightVector{0, 2, 3, 1};
+    DenseElementsAttr permWeightAttr = DenseIntElementsAttr::get(
+        RankedTensorType::get({4}, rewriter.getI64Type()), permWeightVector);
+    Value permWeightList = rewriter.create<tosa::ConstOp>(
+        op->getLoc(), permWeightAttr.getType(), permWeightAttr);
+
+    // calculate new shape
+    SmallVector<int64_t> newWeightShape{
+        weightShape[0], weightShape[2], weightShape[3], weightShape[1]};
+
+    // get new weight type
+    Type newWeightTy =
+        RankedTensorType::get(newWeightShape, weightType.getElementType());
+
+    // create transpose for weight
+    rewriter.replaceOpWithNewOp<tosa::TransposeOp>(
+        op, newWeightTy, weights, permWeightList);
+
+    return success();
+  }
+};
+} // namespace
+
+void populateLoweringONNXConvOpToTOSAPattern(ConversionTarget &target,
+    RewritePatternSet &patterns, TypeConverter &typeConverter,
+    MLIRContext *ctx) {
+  patterns.insert<ONNXConvOpLoweringToTOSA>(typeConverter, ctx);
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -59,9 +59,11 @@ template <typename Op>
 using TOSAOp = typename TOSADialectOp<Op>::Op;
 
 // `Math` directory methods:
-void populateLoweringONNXElementwiseOpToTOSAPattern(
-    mlir::ConversionTarget &, mlir::RewritePatternSet &, mlir::TypeConverter &, mlir:: MLIRContext *);
+void populateLoweringONNXElementwiseOpToTOSAPattern(mlir::ConversionTarget &,
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 
-void populateLoweringONNXConstOpToTOSAPattern(
-    mlir::ConversionTarget &, mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+void populateLoweringONNXConstOpToTOSAPattern(mlir::ConversionTarget &,
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+void populateLoweringONNXConvOpToTOSAPattern(mlir::ConversionTarget &,
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -32,14 +32,10 @@ namespace tosa {
 
 Value createTosaTransposedTensor(PatternRewriter &rewriter, Operation *op,
     Value &value, llvm::ArrayRef<int64_t> perm) {
-  // Create Permutation Attr
-  DenseElementsAttr permAttr = DenseIntElementsAttr::get(
-      RankedTensorType::get({value.getType().cast<TensorType>().getRank()},
-          rewriter.getI64Type()),
-      perm);
   // Create Permutation Const
-  Value permList = tosa::CreateOpAndInfer<tosa::ConstOp>(
-      rewriter, op->getLoc(), permAttr.getType(), permAttr);
+  Value permList = getConstTensor(
+      rewriter, op, perm, {value.getType().cast<TensorType>().getRank()})
+                       .value();
   // get new value type
   Type newValueTy = RankedTensorType::get(
       {-1, -1, -1, -1}, value.getType().cast<ShapedType>().getElementType());
@@ -70,7 +66,7 @@ Value getTosaConstTensorSingleF32(PatternRewriter &rewriter, Operation *op,
 // Default template creates a constant tensor in T.
 template <typename T>
 llvm::Optional<Value> getConstTensor(PatternRewriter &rewriter, Operation *op,
-                                     ArrayRef<T> vec, ArrayRef<int64_t> shape) {
+    ArrayRef<T> vec, ArrayRef<int64_t> shape) {
   uint64_t num_total_elements = 1;
   for (int64_t a : shape) {
     num_total_elements *= a;
@@ -93,8 +89,7 @@ llvm::Optional<Value> getConstTensor(PatternRewriter &rewriter, Operation *op,
 // Template specialization for float
 template <>
 llvm::Optional<Value> getConstTensor<float>(PatternRewriter &rewriter,
-                                            Operation *op, ArrayRef<float> vec,
-                                            ArrayRef<int64_t> shape) {
+    Operation *op, ArrayRef<float> vec, ArrayRef<int64_t> shape) {
   uint64_t num_total_elements = 1;
   for (int64_t a : shape) {
     num_total_elements *= a;
@@ -115,14 +110,10 @@ llvm::Optional<Value> getConstTensor<float>(PatternRewriter &rewriter,
 
 // Template instantiation
 template llvm::Optional<Value> getConstTensor<int32_t>(PatternRewriter &,
-                                                       Operation *,
-                                                       ArrayRef<int32_t> vec,
-                                                       ArrayRef<int64_t> shape);
+    Operation *, ArrayRef<int32_t> vec, ArrayRef<int64_t> shape);
 
 template llvm::Optional<Value> getConstTensor<int64_t>(PatternRewriter &,
-                                                       Operation *,
-                                                       ArrayRef<int64_t> vec,
-                                                       ArrayRef<int64_t> shape);
+    Operation *, ArrayRef<int64_t> vec, ArrayRef<int64_t> shape);
 
 } // namespace tosa
 } // namespace mlir

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
@@ -29,6 +29,10 @@
 namespace mlir {
 namespace tosa {
 
+// Transpose a given TOSA Tensor
+Value createTosaTransposedTensor(PatternRewriter &rewriter, Operation *op,
+    Value &value, llvm::ArrayRef<int64_t> perm);
+
 // Create a 32-bit float constant operator from a float
 // The tensor will have the same rank as shape but with axis 1 (differs from
 // tensorflow impl.)

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -1,24 +1,55 @@
 // RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
 
 
-func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<5x2x75x75xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<5x2x75x75xf32>
-  return %0 : tensor<5x2x75x75xf32>
+func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<?x?x?x?xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+//    [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
+//    [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
+//    [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], %arg2) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [13, 13]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x75x75x2xf32>
+//    [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x75x75x2xf32>, tensor<4xi64>) -> tensor<5x2x75x75xf32>
 }
 
 // -----
-func.func @test_onnx_conv2d_novalue(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) ->  tensor<5x2x965x967xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {pads = [1, 2, 3, 4], dilations = [1, 1]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<5x2x965x967xf32>
-  return %0 : tensor<5x2x965x967xf32>
+func.func @test_onnx_conv2d_novalue(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) ->  tensor<?x?x?x?xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {pads = [1, 2, 3, 4], dilations = [1, 1]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+//    [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
+//    [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
+//    [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
+//    [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x965x967x2xf32>
+//    [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x965x967x2xf32>, tensor<4xi64>) -> tensor<5x2x965x967xf32>
 }
 
 // -----
-func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<7x3x64x64xf32>, %arg2: none) ->  tensor<5x7x74x74xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<7x3x64x64xf32>, none) -> tensor<5x7x74x74xf32>
-  return %0 : tensor<5x7x74x74xf32>
+func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<7x3x64x64xf32>, %arg2: none) ->  tensor<?x?x?x?xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<7x3x64x64xf32>, none) -> tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+//    [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
+//    [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
+//    [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
+//    [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [13, 13]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x74x74x7xf32>
+//    [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x74x74x7xf32>, tensor<4xi64>) -> tensor<5x7x74x74xf32>
 }
 // -----
-func.func @test_onnx_conv2d_no_dilation_pad_stride(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) ->  tensor<5x2x961x961xf32>{
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<5x2x961x961xf32>
-  return %0 : tensor<5x2x961x961xf32>
+func.func @test_onnx_conv2d_no_dilation_pad_stride(%arg0: tensor<5x3x1024x1050xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) ->  tensor<?x?x?x?xf32>{
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) : (tensor<5x3x1024x1050xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+//    [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1050xf32>, tensor<4xi64>) -> tensor<5x1024x1050x3xf32>
+//    [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
+//    [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
+//    [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [13, 13]} : (tensor<5x1024x1050x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x961x987x2xf32>
+//    [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+//    [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x961x987x2xf32>, tensor<4xi64>) -> tensor<5x2x961x987xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -1,24 +1,24 @@
 // RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
 
 
-func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) -> tensor<*xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<5x2x75x75xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<5x2x75x75xf32>
+  return %0 : tensor<5x2x75x75xf32>
 }
 
 // -----
-func.func @test_onnx_conv2d_novalue(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) -> tensor<*xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {pads = [1, 2, 3, 4], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+func.func @test_onnx_conv2d_novalue(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) ->  tensor<5x2x965x967xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {pads = [1, 2, 3, 4], dilations = [1, 1]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<5x2x965x967xf32>
+  return %0 : tensor<5x2x965x967xf32>
 }
 
 // -----
-func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) -> tensor<*xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<7x3x64x64xf32>, %arg2: none) ->  tensor<5x7x74x74xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<7x3x64x64xf32>, none) -> tensor<5x7x74x74xf32>
+  return %0 : tensor<5x7x74x74xf32>
 }
 // -----
-func.func @test_onnx_conv2d_no_dilation_pad_stride(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) -> tensor<*xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) -> tensor<*xf32>
-  return %0 : tensor<*xf32>
+func.func @test_onnx_conv2d_no_dilation_pad_stride(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) ->  tensor<5x2x961x961xf32>{
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<5x2x961x961xf32>
+  return %0 : tensor<5x2x961x961xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -1,59 +1,59 @@
 // RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
 
 
-func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<?x?x?x?xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<?x?x?x?xf32>
-  return %0 : tensor<?x?x?x?xf32>
+func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<5x2x75x75xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<5x2x75x75xf32>
+  return %0 : tensor<5x2x75x75xf32>
 // CHECK-LABEL:  func @test_onnx_conv2d_stride_13
-// CHECK: [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
-// CHECK: [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
-// CHECK: [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], %arg2) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [13, 13]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x75x75x2xf32>
-// CHECK: [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x75x75x2xf32>, tensor<4xi64>) -> tensor<5x2x75x75xf32>
+// CHECK: [[PERM1:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[TRANSINPUT:%.+]] = "tosa.transpose"(%arg0, [[PERM1]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
+// CHECK: [[PERM2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[TRANSKERNEL:%.+]] = "tosa.transpose"(%arg1, [[PERM2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
+// CHECK: [[OUTPUT:%.+]] = "tosa.conv2d"([[TRANSINPUT]], [[TRANSKERNEL]], %arg2) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [13, 13]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x75x75x2xf32>
+// CHECK: [[PERM3:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: {{%.+}} = "tosa.transpose"([[OUTPUT]], [[PERM3]]) : (tensor<5x75x75x2xf32>, tensor<4xi64>) -> tensor<5x2x75x75xf32>
 }
 
 // -----
-func.func @test_onnx_conv2d_novalue(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) ->  tensor<?x?x?x?xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {pads = [1, 2, 3, 4], dilations = [1, 1]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<?x?x?x?xf32>
-  return %0 : tensor<?x?x?x?xf32>
+func.func @test_onnx_conv2d_novalue(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) ->  tensor<5x2x965x967xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {pads = [1, 2, 3, 4], dilations = [1, 1]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<5x2x965x967xf32>
+  return %0 : tensor<5x2x965x967xf32>
 // CHECK-LABEL:  func @test_onnx_conv2d_novalue
-// CHECK: [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
-// CHECK: [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
+// CHECK: [[PERM1:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[TRANSINPUT:%.+]] = "tosa.transpose"(%arg0, [[PERM1]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
+// CHECK: [[PERM2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[TRANSKERNEL:%.+]] = "tosa.transpose"(%arg1, [[PERM2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
 // CHECK: [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
-// CHECK: [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad =  [1, 3, 2, 4], stride = [1, 1]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x965x967x2xf32>
-// CHECK: [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x965x967x2xf32>, tensor<4xi64>) -> tensor<5x2x965x967xf32>
+// CHECK: [[OUTPUT:%.+]] = "tosa.conv2d"([[TRANSINPUT]], [[TRANSKERNEL]], [[BIAS]]) {dilation = [1, 1], pad =  [1, 3, 2, 4], stride = [1, 1]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x965x967x2xf32>
+// CHECK: [[PERM3:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: {{%.+}} = "tosa.transpose"([[OUTPUT]], [[PERM3]]) : (tensor<5x965x967x2xf32>, tensor<4xi64>) -> tensor<5x2x965x967xf32>
 }
 
 // -----
-func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<7x3x64x64xf32>, %arg2: none) ->  tensor<?x?x?x?xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<7x3x64x64xf32>, none) -> tensor<?x?x?x?xf32>
-  return %0 : tensor<?x?x?x?xf32>
+func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<7x3x64x64xf32>, %arg2: none) ->   tensor<5x7x74x74xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<7x3x64x64xf32>, none) ->  tensor<5x7x74x74xf32>
+  return %0 :  tensor<5x7x74x74xf32>
 // CHECK-LABEL:  func @test_onnx_conv2d_no_dilation_pad
-// CHECK: [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
-// CHECK: [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<7x3x64x64xf32>, tensor<4xi64>) -> tensor<7x64x64x3xf32>
+// CHECK: [[PERM1:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[TRANSINPUT:%.+]] = "tosa.transpose"(%arg0, [[PERM1]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
+// CHECK: [[PERM2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[TRANSKERNEL:%.+]] = "tosa.transpose"(%arg1, [[PERM2]]) : (tensor<7x3x64x64xf32>, tensor<4xi64>) -> tensor<7x64x64x3xf32>
 // CHECK: [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<7xf32>} : () -> tensor<7xf32>
-// CHECK: [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [13, 13]} : (tensor<5x1024x1024x3xf32>, tensor<7x64x64x3xf32>, tensor<7xf32>) -> tensor<5x74x74x7xf32>
-// CHECK: [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x74x74x7xf32>, tensor<4xi64>) -> tensor<5x7x74x74xf32>
+// CHECK: [[OUTPUT:%.+]] = "tosa.conv2d"([[TRANSINPUT]], [[TRANSKERNEL]], [[BIAS]]) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [13, 13]} : (tensor<5x1024x1024x3xf32>, tensor<7x64x64x3xf32>, tensor<7xf32>) -> tensor<5x74x74x7xf32>
+// CHECK: [[PERM3:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: {{%.+}} = "tosa.transpose"([[OUTPUT]], [[PERM3]]) : (tensor<5x74x74x7xf32>, tensor<4xi64>) -> tensor<5x7x74x74xf32>
 }
 // -----
 func.func @test_onnx_conv2d_no_dilation_pad_stride(%arg0: tensor<5x3x1024x1050xf32>, %arg1 : tensor<2x3x60x64xf32>, %arg2: none) ->  tensor<5x2x965x987xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) : (tensor<5x3x1024x1050xf32>, tensor<2x3x60x64xf32>, none) ->  tensor<5x2x965x987xf32>
   return %0 : tensor<5x2x965x987xf32>
 // CHECK-LABEL:  func @test_onnx_conv2d_no_dilation_pad_stride
-// CHECK: [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1050xf32>, tensor<4xi64>) -> tensor<5x1024x1050x3xf32>
-// CHECK: [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x60x64xf32>, tensor<4xi64>) -> tensor<2x60x64x3xf32>
+// CHECK: [[PERM1:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[TRANSINPUT:%.+]] = "tosa.transpose"(%arg0, [[PERM1]]) : (tensor<5x3x1024x1050xf32>, tensor<4xi64>) -> tensor<5x1024x1050x3xf32>
+// CHECK: [[PERM2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[TRANSKERNEL:%.+]] = "tosa.transpose"(%arg1, [[PERM2]]) : (tensor<2x3x60x64xf32>, tensor<4xi64>) -> tensor<2x60x64x3xf32>
 // CHECK: [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
-// CHECK: [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<5x1024x1050x3xf32>, tensor<2x60x64x3xf32>, tensor<2xf32>) -> tensor<5x965x987x2xf32>
-// CHECK: [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
-// CHECK: [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x965x987x2xf32>, tensor<4xi64>) -> tensor<5x2x965x987xf32>
+// CHECK: [[OUTPUT:%.+]] = "tosa.conv2d"([[TRANSINPUT]], [[TRANSKERNEL]], [[BIAS]]) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<5x1024x1050x3xf32>, tensor<2x60x64x3xf32>, tensor<2xf32>) -> tensor<5x965x987x2xf32>
+// CHECK: [[PERM3:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: {{%.+}} = "tosa.transpose"([[OUTPUT]], [[PERM3]]) : (tensor<5x965x987x2xf32>, tensor<4xi64>) -> tensor<5x2x965x987xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -4,52 +4,56 @@
 func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) ->  tensor<?x?x?x?xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) ->  tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>
-//    [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
-//    [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
-//    [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], %arg2) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [13, 13]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x75x75x2xf32>
-//    [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x75x75x2xf32>, tensor<4xi64>) -> tensor<5x2x75x75xf32>
+// CHECK-LABEL:  func @test_onnx_conv2d_stride_13
+// CHECK: [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
+// CHECK: [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
+// CHECK: [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], %arg2) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [13, 13]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x75x75x2xf32>
+// CHECK: [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x75x75x2xf32>, tensor<4xi64>) -> tensor<5x2x75x75xf32>
 }
 
 // -----
 func.func @test_onnx_conv2d_novalue(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) ->  tensor<?x?x?x?xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {pads = [1, 2, 3, 4], dilations = [1, 1]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>
-//    [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
-//    [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
-//    [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
-//    [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x965x967x2xf32>
-//    [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x965x967x2xf32>, tensor<4xi64>) -> tensor<5x2x965x967xf32>
+// CHECK-LABEL:  func @test_onnx_conv2d_novalue
+// CHECK: [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
+// CHECK: [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
+// CHECK: [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
+// CHECK: [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad =  [1, 3, 2, 4], stride = [1, 1]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x965x967x2xf32>
+// CHECK: [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x965x967x2xf32>, tensor<4xi64>) -> tensor<5x2x965x967xf32>
 }
 
 // -----
 func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<7x3x64x64xf32>, %arg2: none) ->  tensor<?x?x?x?xf32> {
   %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<7x3x64x64xf32>, none) -> tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>
-//    [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
-//    [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
-//    [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
-//    [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [13, 13]} : (tensor<5x1024x1024x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x74x74x7xf32>
-//    [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x74x74x7xf32>, tensor<4xi64>) -> tensor<5x7x74x74xf32>
+// CHECK-LABEL:  func @test_onnx_conv2d_no_dilation_pad
+// CHECK: [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1024xf32>, tensor<4xi64>) -> tensor<5x1024x1024x3xf32>
+// CHECK: [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<7x3x64x64xf32>, tensor<4xi64>) -> tensor<7x64x64x3xf32>
+// CHECK: [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<7xf32>} : () -> tensor<7xf32>
+// CHECK: [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [13, 13]} : (tensor<5x1024x1024x3xf32>, tensor<7x64x64x3xf32>, tensor<7xf32>) -> tensor<5x74x74x7xf32>
+// CHECK: [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x74x74x7xf32>, tensor<4xi64>) -> tensor<5x7x74x74xf32>
 }
 // -----
-func.func @test_onnx_conv2d_no_dilation_pad_stride(%arg0: tensor<5x3x1024x1050xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) ->  tensor<?x?x?x?xf32>{
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) : (tensor<5x3x1024x1050xf32>, tensor<2x3x64x64xf32>, none) ->  tensor<?x?x?x?xf32>
-  return %0 : tensor<?x?x?x?xf32>
-//    [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1050xf32>, tensor<4xi64>) -> tensor<5x1024x1050x3xf32>
-//    [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x64x64xf32>, tensor<4xi64>) -> tensor<2x64x64x3xf32>
-//    [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
-//    [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [13, 13]} : (tensor<5x1024x1050x3xf32>, tensor<2x64x64x3xf32>, tensor<2xf32>) -> tensor<5x961x987x2xf32>
-//    [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
-//    [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x961x987x2xf32>, tensor<4xi64>) -> tensor<5x2x961x987xf32>
+func.func @test_onnx_conv2d_no_dilation_pad_stride(%arg0: tensor<5x3x1024x1050xf32>, %arg1 : tensor<2x3x60x64xf32>, %arg2: none) ->  tensor<5x2x965x987xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) : (tensor<5x3x1024x1050xf32>, tensor<2x3x60x64xf32>, none) ->  tensor<5x2x965x987xf32>
+  return %0 : tensor<5x2x965x987xf32>
+// CHECK-LABEL:  func @test_onnx_conv2d_no_dilation_pad_stride
+// CHECK: [[VAR0:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR1:%.+]] = "tosa.transpose"(%arg0, [[VAR0]]) : (tensor<5x3x1024x1050xf32>, tensor<4xi64>) -> tensor<5x1024x1050x3xf32>
+// CHECK: [[VAR2:%.+]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR3:%.+]] = "tosa.transpose"(%arg1, [[VAR2]]) : (tensor<2x3x60x64xf32>, tensor<4xi64>) -> tensor<2x60x64x3xf32>
+// CHECK: [[BIAS:%.+]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<2xf32>} : () -> tensor<2xf32>
+// CHECK: [[VAR4:%.+]] = "tosa.conv2d"([[VAR1]], [[VAR3]], [[BIAS]]) {dilation = [1, 1], pad = [0, 0, 0, 0], stride = [1, 1]} : (tensor<5x1024x1050x3xf32>, tensor<2x60x64x3xf32>, tensor<2xf32>) -> tensor<5x965x987x2xf32>
+// CHECK: [[VAR5:%.+]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK: [[VAR6:%.+]] = "tosa.transpose"([[VAR4]], [[VAR5]]) : (tensor<5x965x987x2xf32>, tensor<4xi64>) -> tensor<5x2x965x987xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -2,6 +2,23 @@
 
 
 func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) -> tensor<*xf32> {
-  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {kernel_shape = [64, 64], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) -> tensor<*xf32>
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {dilations = [1, 1], pads = [1, 1, 1, 1], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+
+// -----
+func.func @test_onnx_conv2d_novalue(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) -> tensor<*xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {pads = [1, 2, 3, 4], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+
+// -----
+func.func @test_onnx_conv2d_no_dilation_pad(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) -> tensor<*xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+// -----
+func.func @test_onnx_conv2d_no_dilation_pad_stride(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: none) -> tensor<*xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, none) -> tensor<*xf32>
   return %0 : tensor<*xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Math/Conv.mlir
@@ -1,0 +1,7 @@
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
+
+
+func.func @test_onnx_conv2d_stride_13(%arg0: tensor<5x3x1024x1024xf32>, %arg1 : tensor<2x3x64x64xf32>, %arg2: tensor<2xf32>) -> tensor<*xf32> {
+  %0 = "onnx.Conv"(%arg0, %arg1, %arg2) {kernel_shape = [64, 64], strides = [13, 13]} : (tensor<5x3x1024x1024xf32>, tensor<2x3x64x64xf32>, tensor<2xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}


### PR DESCRIPTION
Right now, only `group=1`  is allowed. TOSA has no representation of group, one would have to manually split the tensors, create multiple conv and concat them again