### PR TITLE
fix: fixes -o for onnx-mllir-opt

### DIFF
--- a/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
+++ b/src/Tools/onnx-mlir-opt/onnx-mlir-opt.cpp
@@ -192,7 +192,12 @@ int main(int argc, char **argv) {
   }
 
   // TODO(imaihal): Change preloadDialectsInContext to false.
-  return failed(mlir::MlirOptMain(output->os(), std::move(file), passPipeline,
-      registry, split_input_file, verify_diagnostics, verify_passes,
-      allowUnregisteredDialects, /*preloadDialectsInContext*/ true));
+  if (failed(mlir::MlirOptMain(output->os(), std::move(file), passPipeline,
+          registry, split_input_file, verify_diagnostics, verify_passes,
+          allowUnregisteredDialects, /*preloadDialectsInContext*/ true))) {
+    return mlir::asMainReturnCode(failure());
+  }
+
+  output->keep();
+  return mlir::asMainReturnCode(success());
 }

--- a/test/mlir/driver/outputfile.mlir
+++ b/test/mlir/driver/outputfile.mlir
@@ -1,0 +1,2 @@
+// RUN: onnx-mlir-opt %s -o %t
+// RUN: test -f %t


### PR DESCRIPTION
-o never created a file when used. In the old cold the file is deleted when the scope is left. Now the file remains.