### PR TITLE
[onnx-to-tosa] add shapehelper for maxpool to support ceil_mode padding

### DIFF
--- a/src/Conversion/ONNXToTOSA/CMakeLists.txt
+++ b/src/Conversion/ONNXToTOSA/CMakeLists.txt
@@ -4,6 +4,7 @@ add_onnx_mlir_library(OMONNXToTOSA
   ConvertONNXToTOSA.cpp
   ONNXToTOSALegalizeUtils.cpp
   ONNXToTOSACommon.cpp
+  DialectBuilder.cpp
 
   Math/Elementwise.cpp
   Math/Conv2D.cpp

--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -16,6 +16,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
+#include <mlir/Dialect/Arith/IR/Arith.h>
 
 using namespace mlir;
 
@@ -93,7 +94,8 @@ void FrontendToTosaLoweringPass::runOnOperation() {
   });
 
   // Define legal dialects and operations
-  target.addLegalDialect<mlir::tosa::TosaDialect, mlir::func::FuncDialect>();
+  target.addLegalDialect<mlir::tosa::TosaDialect, mlir::func::FuncDialect,
+      mlir::arith::ArithDialect>();
 
   // Define patterns
   populateONNXToTOSAConversionPattern(target, patterns, typeConverter, context);

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -10,7 +10,7 @@
 // =============================================================================
 //
 // This file contains the dialect build for the TOSA dialect. Uses the same
-// implementation as MHLO with minor differences.
+// implementation as ONNXToMhlo with minor differences.
 //
 //===----------------------------------------------------------------------===//
 

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -1,0 +1,62 @@
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//====------ DialectBuilder.hpp - TOSA dialect builder --------------------===//
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file contains the dialect build for the TOSA dialect. Uses the same
+// implementation as MHLO with minor differences.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+
+#include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+// =============================================================================
+// IndexExpr Builder for Lowering using Shape/TOSA Dialect.
+// =============================================================================
+
+// Return null if none is found.
+DenseElementsAttr IndexExprBuilderForTosa::getConst(Value value) {
+  auto definingOp = value.getDefiningOp();
+  // If we have a cast between index/integer, skip it, i.e. get the defining op
+  // that is the input to the cast.
+  if (auto castOp = dyn_cast_or_null<arith::IndexCastOp>(definingOp)) {
+    Value input = castOp.getIn();
+    definingOp = input.getDefiningOp();
+  }
+  if (auto constOp = dyn_cast_or_null<tosa::ConstOp>(definingOp)) {
+    if (constOp.getValueAttr())
+      return constOp.getValueAttr().dyn_cast<DenseElementsAttr>();
+  } else if (auto constOp = dyn_cast_or_null<ONNXConstantOp>(definingOp)) {
+    if (constOp.value().has_value())
+      return constOp.valueAttr().dyn_cast<DenseElementsAttr>();
+  }
+  return nullptr;
+}
+
+Value IndexExprBuilderForTosa::getVal(Value intArrayVal, uint64_t i) {
+  MultiDialectBuilder<AffineBuilder, MathBuilder> create(*this);
+  // Need to add some acceptable dialects to MHLO conversion.
+  llvm_unreachable(
+      "unimplemented (see IndexExprBuilderForKrnl for functionality).");
+}
+
+Value IndexExprBuilderForTosa::getShapeVal(
+    Value tensorOrMemrefValue, uint64_t i) {
+  ShapeBuilder createShape(*this);
+  return createShape.dim(tensorOrMemrefValue, i);
+}
+
+} // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//====------ DialectBuilder.hpp - TOSA dialect builder --------------------===//
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file contains the dialect build for the TOSA dialect. Uses the same
+// implementation as MHLO with minor differences.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Value.h"
+
+#include "src/Dialect/Mlir/DialectBuilder.hpp"
+#include "src/Dialect/Mlir/IndexExpr.hpp"
+#include "src/Dialect/Mlir/IndexExprBuilder.hpp"
+
+namespace onnx_mlir {
+
+// =============================================================================
+// IndexExpr Builder for Shape lowering
+// =============================================================================
+
+struct IndexExprBuilderForTosa : IndexExprBuilder {
+  IndexExprBuilderForTosa(mlir::Location loc) : IndexExprBuilder(loc) {}
+  IndexExprBuilderForTosa(mlir::OpBuilder &b, mlir::Location loc)
+      : IndexExprBuilder(b, loc) {}
+  IndexExprBuilderForTosa(const DialectBuilder &db) : IndexExprBuilder(db) {}
+  virtual ~IndexExprBuilderForTosa() {}
+
+protected:
+  mlir::DenseElementsAttr getConst(mlir::Value value) final;
+  mlir::Value getVal(mlir::Value intArrayVal, uint64_t i) final;
+  mlir::Value getShapeVal(mlir::Value tensorOrMemrefValue, uint64_t i) final;
+};
+
+// Recursive class specialized for AffineBuilder refereed to as affine.
+template <class... Ts>
+struct MultiDialectBuilder<IndexExprBuilderForTosa, Ts...>
+    : MultiDialectBuilder<Ts...> {
+  MultiDialectBuilder(mlir::OpBuilder &b, mlir::Location loc)
+      : MultiDialectBuilder<Ts...>(b, loc), tosaIE(b, loc) {}
+  MultiDialectBuilder(const DialectBuilder &db)
+      : MultiDialectBuilder<Ts...>(db), tosaIE(db) {}
+  IndexExprBuilderForTosa tosaIE;
+};
+
+} // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/NN/MaxPoolSingleOut.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/MaxPoolSingleOut.cpp
@@ -45,9 +45,10 @@ llvm::SmallVector<int64_t> getCeilConstants(llvm::ArrayRef<int64_t> inputShape,
       tosa::createInt64VectorFromIndexExpr(shapeHelper.pads);
 
   // Check if the idiv_check for the output dimentions in
-  // https://www.mlplatform.org/tosa/tosa_spec.html#_max_pool2d has no rest. If
-  // it has a rest, we add size(stride) to the end of the padding dimension to
-  // get one dimension up. Height and width need to have seperate values.
+  // https://www.mlplatform.org/tosa/tosa_spec.html#_max_pool2d has no
+  // remainder. If it has a remainder, we add size(stride) to the end of the
+  // padding dimension to get one dimension up. Height and width need to have
+  // seperate values.
   int64_t xAxis = 0;
   if ((inputShape[2] + padsVec[0] + padsVec[2] - kernelShapeVec[0]) %
       stridesVec[0])
@@ -95,7 +96,7 @@ public:
 
     if (inputType.getShape().size() != 4) {
       return rewriter.notifyMatchFailure(
-          maxpoolOp, "TOSA only supports tensors with size 4");
+          maxpoolOp, "TOSA only supports maxpool 2d");
     }
 
     // Construct the transposed type for the new MaxPool OP
@@ -104,14 +105,12 @@ public:
         inputType.getElementType());
 
     if (dilations) {
-      return rewriter.notifyMatchFailure(maxpoolOp,
-          "dilations attribute is unsupported by TOSA and its value "
-          "will be ignored");
+      return rewriter.notifyMatchFailure(
+          maxpoolOp, "dilations attribute is unsupported by TOSA");
     }
     if (storageOrder && storageOrder.getSInt() != 0) {
-      return rewriter.notifyMatchFailure(maxpoolOp,
-          "storage_order attribute is unsupported by TOSA and its "
-          "value will be ignored");
+      return rewriter.notifyMatchFailure(
+          maxpoolOp, "storage_order attribute is unsupported by TOSA");
     }
 
     // ONNX Mlir uses NCHW as an input while TOSA expects NHWC. Insert a

--- a/src/Conversion/ONNXToTOSA/NN/MaxPoolSingleOut.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/MaxPoolSingleOut.cpp
@@ -20,6 +20,7 @@
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
 #include "src/Dialect/ONNX/ONNXOps/NewShapeHelper.hpp"
 #include "llvm/ADT/ArrayRef.h"
+#include <src/Dialect/Mlir/IndexExpr.hpp>
 
 using namespace mlir;
 
@@ -27,96 +28,125 @@ namespace onnx_mlir {
 
 namespace {
 
-class ONNXMaxPoolSingleOutOpLoweringToTOSA
-    : public OpConversionPattern<ONNXMaxPoolSingleOutOp> {
+// This calculates the values that need to be added to the padding in order to
+// simulate the ceil mode
+llvm::SmallVector<int64_t> getCeilConstants(llvm::ArrayRef<int64_t> inputShape,
+    const NewONNXMaxPoolSingleOutOpShapeHelper &shapeHelper) {
+  // This avoids having more if statements when creating the padding const.
+  if (!shapeHelper.ceilMode)
+    return llvm::SmallVector<int64_t>{0, 0};
+
+  SmallVector<int64_t, 2> kernelShapeVec =
+      tosa::createInt64VectorFromIndexExpr(shapeHelper.kernelShape);
+
+  // Get stride and pad vectors.
+  SmallVector<int64_t, 2> stridesVec = shapeHelper.strides;
+  SmallVector<int64_t, 4> padsVec =
+      tosa::createInt64VectorFromIndexExpr(shapeHelper.pads);
+
+  // Check if the idiv_check for the output dimentions in
+  // https://www.mlplatform.org/tosa/tosa_spec.html#_max_pool2d has no rest. If
+  // it has a rest, we add size(stride) to the end of the padding dimension to
+  // get one dimension up. Height and width need to have seperate values.
+  int64_t xAxis = 0;
+  if ((inputShape[2] + padsVec[0] + padsVec[2] - kernelShapeVec[0]) %
+      stridesVec[0])
+    xAxis = stridesVec[0];
+
+  int64_t yAxis = 0;
+  if ((inputShape[3] + padsVec[1] + padsVec[3] - kernelShapeVec[1]) %
+      stridesVec[1])
+    yAxis = stridesVec[1];
+
+  return llvm::SmallVector<int64_t>{xAxis, yAxis};
+}
+
+class ONNXMaxPoolSingleOutOpLoweringToTOSA : public ConversionPattern {
 public:
-  using OpConversionPattern<ONNXMaxPoolSingleOutOp>::OpConversionPattern;
+  ONNXMaxPoolSingleOutOpLoweringToTOSA(MLIRContext *ctx)
+      : ConversionPattern(ONNXMaxPoolSingleOutOp::getOperationName(), 1, ctx) {}
+  // using ConversionPattern<ONNXMaxPoolSingleOutOp>::ConversionPattern;
   using OpAdaptor = typename ONNXMaxPoolSingleOutOp::Adaptor;
   LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
-      ConversionPatternRewriter &rewriter) const override {
+      ConversionPatternRewriter &rewriter) const final {
     auto maxpoolOp = llvm::cast<ONNXMaxPoolSingleOutOp>(op);
     Location loc = op->getLoc();
     OpAdaptor adaptor(operands, op->getAttrDictionary());
     // Get shape.
     IndexExprBuilderForTosa createTosaIE(rewriter, loc);
     NewONNXMaxPoolSingleOutOpShapeHelper shapeHelper(
-        op, adaptor.getOperands(), &createTosaIE);
+        op, operands, &createTosaIE);
     shapeHelper.computeShapeAndAssertOnFailure();
 
-    shapeHelper.pads;
-    Input = adaptor.X();
-    // - The attribute Ceil_mode is ignored because its effect is already
-    // impacting the return type of the operator
-    // - The attribute auto_pad is ignored because it is marked as deprecated
-    // for ONNX
-    // - The attributes storage_order and dilations is also unsupported
-    mlir::StringAttr autoPad = adaptor.auto_padAttr();
+    Value input = adaptor.X();
+
+    // The attributes storage_order and dilations are unsupported
     mlir::IntegerAttr storageOrder = adaptor.storage_orderAttr();
     mlir::ArrayAttr dilations = adaptor.dilationsAttr();
     mlir::ArrayAttr kernelShape = adaptor.kernel_shapeAttr();
     mlir::ArrayAttr pads = adaptor.padsAttr();
     mlir::ArrayAttr strides = adaptor.stridesAttr();
 
-    if (Input.getType().isa<MemRefType>()) {
+    if (input.getType().isa<MemRefType>()) {
       return rewriter.notifyMatchFailure(
           op, "memrefs as inputs are unsupported by TOSA");
     }
-    auto InputType = Input.getType().cast<TensorType>();
-    auto resultType = maxpoolOp.getResult().getType();
-    auto resultShape = resultType.cast<TensorType>().getShape();
+    auto inputType = input.getType().cast<TensorType>();
+
+    if (inputType.getShape().size() != 4) {
+      return rewriter.notifyMatchFailure(
+          maxpoolOp, "TOSA only supports tensors with size 4");
+    }
+
     // Construct the transposed type for the new MaxPool OP
     Type newResultType = RankedTensorType::get(
-        {resultShape[0], resultShape[2], resultShape[3], resultShape[1]},
-        InputType.getElementType());
+        llvm::SmallVector<int64_t, 4>(inputType.getShape().size(), -1),
+        inputType.getElementType());
 
-    if (autoPad != "NOTSET") {
-      maxpoolOp.emitWarning(
-          "auto_pad attribute is deprecated and its value will be ignored");
-    }
     if (dilations) {
-      maxpoolOp.emitWarning(
+      return rewriter.notifyMatchFailure(maxpoolOp,
           "dilations attribute is unsupported by TOSA and its value "
           "will be ignored");
     }
     if (storageOrder && storageOrder.getSInt() != 0) {
-      maxpoolOp.emitWarning(
+      return rewriter.notifyMatchFailure(maxpoolOp,
           "storage_order attribute is unsupported by TOSA and its "
           "value will be ignored");
     }
 
     // ONNX Mlir uses NCHW as an input while TOSA expects NHWC. Insert a
     // transpose to change the format
-    Input = tosa::createTosaTransposedTensor(
-        rewriter, maxpoolOp, Input, {0, 2, 3, 1});
+    input = tosa::createTosaTransposedTensor(
+        rewriter, maxpoolOp, input, {0, 2, 3, 1});
 
-    // Pads and Strides are optionals for ONNX but mandatory for TOSA
-    if (!pads) {
-      pads = rewriter.getI64ArrayAttr({0, 0, 0, 0});
-    } else {
-      llvm::SmallVector<int64_t, 4> transposedPads =
-          extractFromI64ArrayAttr(pads);
-      pads = rewriter.getI64ArrayAttr({transposedPads[0], transposedPads[2],
-          transposedPads[1], transposedPads[3]});
-    }
-    if (!strides) {
-      strides = rewriter.getI64ArrayAttr({1, 1});
-    }
+    // When ceil mode is 1, we need to add values to the padding
+    const llvm::SmallVector<int64_t, 4> ceilConstants =
+        getCeilConstants(inputType.getShape(), shapeHelper);
+    llvm::SmallVector<int64_t, 4> transposedPads =
+        tosa::createInt64VectorFromIndexExpr(shapeHelper.pads);
 
-    Input = rewriter
-                .create<mlir::tosa::MaxPool2dOp>(
-                    loc, newResultType, Input, kernelShape, strides, pads)
-                .getResult();
+    // reorder padding values
+    pads = rewriter.getI64ArrayAttr(
+        {transposedPads[0], transposedPads[2] + ceilConstants[0],
+            transposedPads[1], transposedPads[3] + ceilConstants[1]});
+
+    strides = rewriter.getI64ArrayAttr(shapeHelper.strides);
+
+    input = tosa::CreateOpAndInfer<mlir::tosa::MaxPool2dOp>(
+        rewriter, loc, newResultType, input, kernelShape, strides, pads);
+
     // Revert to original shape (NCHW)
     // Construct the old result shape out of the new one
-    auto newInputType = Input.getType().cast<RankedTensorType>().getShape();
+    auto newInputType = input.getType().cast<RankedTensorType>().getShape();
     Value sourceTensor =
         tosa::getConstTensor<int32_t>(rewriter, maxpoolOp, {0, 3, 1, 2}, {4})
             .value();
+
     Type transposedResultType = RankedTensorType::get(
-        {newInputType[0], newInputType[3], newInputType[1], newInputType[2]},
-        InputType.getElementType());
+        llvm::SmallVector<int64_t, 4>(newInputType.size(), -1),
+        inputType.getElementType());
     tosa::CreateReplaceOpAndInfer<mlir::tosa::TransposeOp>(
-        rewriter, maxpoolOp, transposedResultType, Input, sourceTensor);
+        rewriter, maxpoolOp, transposedResultType, input, sourceTensor);
     return success();
   }
 };
@@ -126,7 +156,7 @@ public:
 void populateLoweringONNXMaxPoolSingleOutOpToTOSAPattern(
     ConversionTarget &target, RewritePatternSet &patterns,
     TypeConverter &typeConverter, MLIRContext *ctx) {
-  patterns.insert<ONNXMaxPoolSingleOutOpLoweringToTOSA>(typeConverter, ctx);
+  patterns.insert<ONNXMaxPoolSingleOutOpLoweringToTOSA>(ctx);
 }
 
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/NN/MaxPoolSingleOut.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/MaxPoolSingleOut.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
 #include "llvm/ADT/ArrayRef.h"

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -35,10 +35,9 @@ namespace tosa {
 
 llvm::SmallVector<int64_t> createInt64VectorFromIndexExpr(
     llvm::ArrayRef<IndexExpr> indexVector) {
-  llvm::SmallVector<int64_t, 4> literalVector;
-  for (const auto &indexExpr : indexVector) {
-    literalVector.push_back(indexExpr.getLiteral());
-  }
+  llvm::SmallVector<int64_t, 4> literalVector(indexVector.size());
+  llvm::transform(indexVector, literalVector.begin(),
+      [](const auto &indexExpr) { return indexExpr.getLiteral(); });
   return literalVector;
 }
 

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -27,14 +27,23 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/DerivedTypes.h"
 #include <cstdint>
+#include <src/Dialect/Mlir/IndexExpr.hpp>
 
 using namespace mlir;
 namespace onnx_mlir {
 namespace tosa {
 
-Value sliceTensor(PatternRewriter &rewriter, Operation *op,
-    Value &inputConst, const llvm::ArrayRef<int64_t> &size,
-    const llvm::ArrayRef<int64_t> &start) {
+llvm::SmallVector<int64_t> createInt64VectorFromIndexExpr(
+    llvm::ArrayRef<IndexExpr> indexVector) {
+  llvm::SmallVector<int64_t, 4> literalVector;
+  for (const auto &indexExpr : indexVector) {
+    literalVector.push_back(indexExpr.getLiteral());
+  }
+  return literalVector;
+}
+
+Value sliceTensor(PatternRewriter &rewriter, Operation *op, Value &inputConst,
+    const llvm::ArrayRef<int64_t> &size, const llvm::ArrayRef<int64_t> &start) {
   ArrayAttr sizeAttr = rewriter.getI64ArrayAttr(size);
   ArrayAttr startAttr = rewriter.getI64ArrayAttr(start);
   Value newSliceInput =
@@ -51,12 +60,14 @@ Value createTosaTransposedTensor(PatternRewriter &rewriter, Operation *op,
   Value permList = getConstTensor(
       rewriter, op, perm, {value.getType().cast<RankedTensorType>().getRank()})
                        .value();
+  auto valueType = value.getType().cast<ShapedType>();
   // get new value type
-  Type newValueTy = RankedTensorType::get(
-      {-1, -1, -1, -1}, value.getType().cast<ShapedType>().getElementType());
+  Type newValueType = RankedTensorType::get(
+      llvm::SmallVector<int64_t, 4>(valueType.getShape().size(), -1),
+      valueType.getElementType());
   // create transpose for value
   Value newValue = CreateOpAndInfer<mlir::tosa::TransposeOp>(
-      rewriter, op->getLoc(), newValueTy, value, permList);
+      rewriter, op->getLoc(), newValueType, value, permList);
   return newValue;
 }
 

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
@@ -25,9 +25,14 @@
 #include "mlir/IR/PatternMatch.h"                 // from @llvm-project
 #include "mlir/Interfaces/InferTypeOpInterface.h" // from @llvm-project
 #include "mlir/Support/LLVM.h"                    // from @llvm-project
+#include <src/Dialect/Mlir/IndexExpr.hpp>
 
 namespace onnx_mlir {
 namespace tosa {
+
+// Get a vector of indexExpr and extract the Int64 values
+llvm::SmallVector<int64_t> createInt64VectorFromIndexExpr(
+    llvm::ArrayRef<IndexExpr> indexVector);
 
 // Slices a TOSA Tensor with the specific size and start values
 mlir::Value sliceTensor(mlir::PatternRewriter &rewriter, mlir::Operation *op,


### PR DESCRIPTION
Maxpool didn't pass the execution test when `ceil = 1`. This adds values to the padding, which should have the same effect.