### PR TITLE
[onnx-to-tosa] Convert ResizeOp from ONNX to TOSA

### DIFF
--- a/src/Conversion/ONNXToTOSA/CMakeLists.txt
+++ b/src/Conversion/ONNXToTOSA/CMakeLists.txt
@@ -12,6 +12,7 @@ add_onnx_mlir_library(OMONNXToTOSA
   Math/Gemm.cpp
   Math/ReduceMean.cpp
   Tensor/Reshape.cpp
+  Tensor/Resize.cpp
   Tensor/Constant.cpp
   Tensor/PaddingOp.cpp
   Tensor/Flatten.cpp

--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -37,6 +37,8 @@ void populateONNXToTOSAConversionPattern(ConversionTarget &target,
   // Tensor
   populateLoweringONNXReshapeOpToTOSAPattern(
       target, patterns, typeConverter, ctx);
+  populateLoweringONNXResizeOpToTOSAPattern(
+      target, patterns, typeConverter, ctx);
   populateLoweringONNXConstOpToTOSAPattern(
       target, patterns, typeConverter, ctx);
   populateLoweringONNXPadOpToTOSAPattern(target, patterns, typeConverter, ctx);

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -88,6 +88,8 @@ void populateLoweringONNXMaxPoolSingleOutOpToTOSAPattern(
 // `Tensor` directory methods:
 void populateLoweringONNXReshapeOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+void populateLoweringONNXResizeOpToTOSAPattern(mlir::ConversionTarget &,
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXConstOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXPadOpToTOSAPattern(mlir::ConversionTarget &,

--- a/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
@@ -2,13 +2,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//===---------------- Resize.cpp - Resize Op-----------===//
+//===---------------- Resize.cpp - Resize Op-------------------------------===//
 //
 // Copyright (c) 2022 Advanced Micro Devices, Inc.
 //
 // =============================================================================
 //
-// This file lowers ONNX Resize operator to TOSA dialect.
+// This file lowers the ONNX Resize operator to TOSA dialect.
 //
 //===----------------------------------------------------------------------===//
 
@@ -16,16 +16,8 @@
 #include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
-#include "src/Dialect/ONNX/ONNXOps/NewShapeHelper.hpp"
 #include <cstdint>
-#include <llvm/ADT/APFloat.h>
-#include <llvm/ADT/ArrayRef.h>
-#include <llvm/ADT/STLExtras.h>
-#include <llvm/ADT/SmallVector.h>
-#include <llvm/ADT/StringRef.h>
 #include <numeric>
-#include <src/Dialect/Mlir/IndexExpr.hpp>
-#include <src/Dialect/ONNX/ONNXOps/OpHelper.hpp>
 
 using namespace mlir;
 

--- a/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
@@ -90,9 +90,10 @@ public:
         rewriter, resizeOp, input, {0, 2, 3, 1});
 
     bool alignCorners = coordinateTransformationMode == "align_corners";
-    bool halfPixel = coordinateTransformationMode == "align_corners";
+    bool halfPixel = coordinateTransformationMode == "half_pixel";
     bool isBilinear = mode == "linear";
     bool isNearest = mode == "nearest";
+    bool floor = nearestMode == "floor";
     StringRef resizeMode = isBilinear ? "BILINEAR" : "NEAREST_NEIGHBOR";
 
     auto inputShape = inputType.getShape();
@@ -127,7 +128,11 @@ public:
       d = 2 * d / gcd;
 
       // If half pixel centers we need to sample half a pixel inward.
-      offset = halfPixel ? d / 2 : 0;
+      offset = halfPixel ? (d - n) / 2 : 0;
+      // If round_half_up we need to adjust the offset
+      if (floor) {
+        offset -= n / 2;
+      }
 
       // If nearest neighbours we need to guarantee we round up.
       if (isNearest && alignCorners) {

--- a/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Resize.cpp
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------------- Resize.cpp - Resize Op-----------===//
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file lowers ONNX Resize operator to TOSA dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+#include "src/Dialect/ONNX/ONNXOps/NewShapeHelper.hpp"
+#include <cstdint>
+#include <llvm/ADT/APFloat.h>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <numeric>
+#include <src/Dialect/Mlir/IndexExpr.hpp>
+#include <src/Dialect/ONNX/ONNXOps/OpHelper.hpp>
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+namespace {
+
+class ONNXResizeOpLoweringToTOSA : public ConversionPattern {
+public:
+  ONNXResizeOpLoweringToTOSA(MLIRContext *ctx)
+      : ConversionPattern(ONNXResizeOp::getOperationName(), 1, ctx) {}
+  using OpAdaptor = typename ONNXResizeOp::Adaptor;
+
+  LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const final {
+    auto resizeOp = llvm::cast<ONNXResizeOp>(op);
+    Location loc = op->getLoc();
+    OpAdaptor adaptor(operands, op->getAttrDictionary());
+
+    Value input = adaptor.X();
+    auto inputType = input.getType().dyn_cast<RankedTensorType>();
+
+    auto resultType =
+        resizeOp.getResult().getType().dyn_cast<RankedTensorType>();
+
+    StringRef mode = adaptor.mode();
+    StringRef nearestMode = adaptor.nearest_mode();
+    StringRef coordinateTransformationMode =
+        adaptor.coordinate_transformation_mode();
+    int64_t excludeOutside = adaptor.exclude_outside();
+
+    if (inputType.getRank() != 4) {
+      return rewriter.notifyMatchFailure(
+          resizeOp, "TOSA only support 4D tensors as input of resize.");
+    }
+
+    if (mode == "cubic") {
+      return rewriter.notifyMatchFailure(
+          resizeOp, "TOSA does not support cubic interpolation.");
+    }
+
+    if (nearestMode == "ceil" || nearestMode == "round_prefer_floor") {
+      return rewriter.notifyMatchFailure(resizeOp,
+          "TOSA does not support ceil and round_prefer_floor as nearestMode.");
+    }
+
+    // TODO: Maybe it does support it with border? Investigate on this.
+    if (excludeOutside) {
+      return rewriter.notifyMatchFailure(
+          resizeOp, "TOSA does not support excludeOutside.");
+    }
+
+    // TODO: special handling for pytorch_half_pixel
+    if (coordinateTransformationMode == "tf_crop_and_resize" ||
+        coordinateTransformationMode == "pytorch_half_pixel") {
+      return rewriter.notifyMatchFailure(resizeOp,
+          "TOSA does not support tf_crop_and_resize or pytorch_half_pixel.");
+    }
+
+    // Convert input [N,IC,IH,IW] -> [N,IH,IW,IC]
+    Value newInput = tosa::createTosaTransposedTensor(
+        rewriter, resizeOp, input, {0, 2, 3, 1});
+
+    bool alignCorners = coordinateTransformationMode == "align_corners";
+    bool halfPixel = coordinateTransformationMode == "align_corners";
+    bool isBilinear = mode == "linear";
+    bool isNearest = mode == "nearest";
+    StringRef resizeMode = isBilinear ? "BILINEAR" : "NEAREST_NEIGHBOR";
+
+    auto inputShape = inputType.getShape();
+    auto outputShape = resultType.getShape();
+
+    int64_t inputHeight = inputShape[2];
+    int64_t inputWidth = inputShape[3];
+    int64_t outputHeight = outputShape[2];
+    int64_t outputWidth = outputShape[3];
+
+    // Align corners sets the scaling ratio to (OH - 1)/(IH - 1)
+    // rather than OH / IH. Similarly for width.
+    auto normalize = [&](int64_t input, int64_t output, int64_t &n, int64_t &d,
+                         int64_t &offset, int64_t &border) {
+      // Dimension is length 1, we are just sampling from one value.
+      if (input == 1) {
+        n = 1;
+        d = 1;
+        offset = 0;
+        border = output - 1;
+        return;
+      }
+
+      // Apply if aligned and capable to be aligned.
+      bool applyAligned = alignCorners && (output > 1);
+      n = applyAligned ? (output - 1) : output;
+      d = applyAligned ? (input - 1) : input;
+
+      // Simplify the scalers, make sure they are even values.
+      int gcd = std::gcd(n, d);
+      n = 2 * n / gcd;
+      d = 2 * d / gcd;
+
+      // If half pixel centers we need to sample half a pixel inward.
+      offset = halfPixel ? d / 2 : 0;
+
+      // If nearest neighbours we need to guarantee we round up.
+      if (isNearest && alignCorners) {
+        offset += n / 2;
+      }
+
+      if (isBilinear && halfPixel) {
+        offset -= n / 2;
+      }
+
+      // We can compute this directly based on previous values.
+      border = d * (output - 1) - n * (input - 1) + offset;
+    };
+
+    int64_t scale_y_n, scale_y_d, offset_y, border_y;
+    int64_t scale_x_n, scale_x_d, offset_x, border_x;
+    normalize(
+        inputHeight, outputHeight, scale_y_n, scale_y_d, offset_y, border_y);
+    normalize(
+        inputWidth, outputWidth, scale_x_n, scale_x_d, offset_x, border_x);
+
+    auto scale =
+        rewriter.getI64ArrayAttr({scale_y_n, scale_y_d, scale_x_n, scale_x_d});
+    auto offset = rewriter.getI64ArrayAttr({offset_y, offset_x});
+    auto border = rewriter.getI64ArrayAttr({border_y, border_x});
+    auto resizeModeAttr = rewriter.getStringAttr(resizeMode);
+    Type newOutputType = RankedTensorType::get(
+        {-1, -1, -1, -1}, resultType.cast<ShapedType>().getElementType());
+
+    Value resize = tosa::CreateOpAndInfer<mlir::tosa::ResizeOp>(rewriter, loc,
+        newOutputType, newInput, scale, offset, border, resizeModeAttr);
+
+    // Convert output [N,OH,OW,OC] -> [N,OC,OH,OW]
+    Value newOutput = tosa::createTosaTransposedTensor(
+        rewriter, resizeOp, resize, {0, 3, 1, 2});
+
+    rewriter.replaceOp(resizeOp, newOutput);
+
+    return success();
+  }
+};
+
+} // namespace
+
+void populateLoweringONNXResizeOpToTOSAPattern(ConversionTarget &target,
+    RewritePatternSet &patterns, TypeConverter &typeConverter,
+    MLIRContext *ctx) {
+  patterns.insert<ONNXResizeOpLoweringToTOSA>(ctx);
+}
+
+} // namespace onnx_mlir

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Resize.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Resize.mlir
@@ -1,0 +1,17 @@
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
+
+func.func @test_resize(%arg0: tensor<1x2x3x4xf32>) -> tensor<1x2x3x12xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 1.000000e+00, 3.000000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
+    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "floor"} : (tensor<1x2x3x4xf32>, none, tensor<4xf32>, none) -> tensor<1x2x3x12xf32>
+    return %2 : tensor<1x2x3x12xf32>
+}
+
+// -----
+
+func.func @test_resize2(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 3, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor"} : (tensor<1x1x3x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x3x12xf32>
+    return %2 : tensor<1x1x3x12xf32>
+}

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Resize.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Resize.mlir
@@ -1,17 +1,27 @@
 // RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
 
-func.func @test_resize(%arg0: tensor<1x2x3x4xf32>) -> tensor<1x2x3x12xf32> {
+
+
+func.func @test_resize3(%arg0: tensor<1x1x1x4xf32>) -> tensor<1x1x1x12xf32> {
     %0 = "onnx.NoValue"() {value} : () -> none
-    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 1.000000e+00, 3.000000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
-    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "floor"} : (tensor<1x2x3x4xf32>, none, tensor<4xf32>, none) -> tensor<1x2x3x12xf32>
-    return %2 : tensor<1x2x3x12xf32>
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 1, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor"} : (tensor<1x1x1x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x1x12xf32>
+    return %2 : tensor<1x1x1x12xf32>
+}
+
+// -----
+func.func @test_resize2(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 3, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "round_prefer_ceil"} : (tensor<1x1x3x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x3x12xf32>
+    return %2 : tensor<1x1x3x12xf32>
 }
 
 // -----
 
-func.func @test_resize2(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+func.func @test_resize(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
     %0 = "onnx.NoValue"() {value} : () -> none
-    %1 = "onnx.Constant"() {value = dense<[1, 1, 3, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
-    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor"} : (tensor<1x1x3x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x3x12xf32>
+    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 1.000000e+00, 3.000000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
+    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "floor"} : (tensor<1x1x3x4xf32>, none, tensor<4xf32>, none) -> tensor<1x1x3x12xf32>
     return %2 : tensor<1x1x3x12xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Resize.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Resize.mlir
@@ -1,27 +1,90 @@
-// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa %s -split-input-file | FileCheck %s
+// RUN: onnx-mlir-opt --shape-inference --convert-onnx-to-tosa -cse %s -split-input-file | FileCheck %s
 
+func.func @test_resize_pytorch_half_pixel_linear(%arg0: tensor<1x1x2x4xf32>) -> tensor<1x1x4x8xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 2.000000e+00, 2.000000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
+    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {coordinate_transformation_mode = "pytorch_half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "round_prefer_floor"} : (tensor<1x1x2x4xf32>, none, tensor<4xf32>, none) -> tensor<1x1x4x8xf32>
+    return %2 : tensor<1x1x4x8xf32>
+// CHECK-LABEL:  func.func @test_resize_pytorch_half_pixel_linear(
+// CHECK:  %[[VAL_1:.*]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_2:.*]] = "tosa.transpose"(%arg0, %[[VAL_1]]) : (tensor<1x1x2x4xf32>, tensor<4xi64>) -> tensor<1x2x4x1xf32>
+// CHECK:  %[[VAL_3:.*]] = "tosa.resize"(%[[VAL_2]]) {border = [1, 1], mode = "BILINEAR", offset = [-1, -1], scale = [4, 2, 4, 2]} : (tensor<1x2x4x1xf32>) -> tensor<1x4x8x1xf32>
+// CHECK:  %[[VAL_4:.*]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_5:.*]] = "tosa.transpose"(%[[VAL_3]], %[[VAL_4]]) : (tensor<1x4x8x1xf32>, tensor<4xi64>) -> tensor<1x1x4x8xf32>
+// CHECK:  return %[[VAL_5]] : tensor<1x1x4x8xf32>
+}
 
-
-func.func @test_resize3(%arg0: tensor<1x1x1x4xf32>) -> tensor<1x1x1x12xf32> {
+// -----
+func.func @test_resize_half_pixel_nearest_floor(%arg0: tensor<1x1x1x4xf32>) -> tensor<1x1x1x12xf32> {
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.Constant"() {value = dense<[1, 1, 1, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
     %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor"} : (tensor<1x1x1x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x1x12xf32>
     return %2 : tensor<1x1x1x12xf32>
+// CHECK-LABEL:  func.func @test_resize_half_pixel_nearest_floor(
+// CHECK:  %[[VAL_1:.*]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_2:.*]] = "tosa.transpose"(%arg0, %[[VAL_1]]) : (tensor<1x1x1x4xf32>, tensor<4xi64>) -> tensor<1x1x4x1xf32>
+// CHECK:  %[[VAL_3:.*]] = "tosa.resize"(%[[VAL_2]]) {border = [0, -1], mode = "NEAREST_NEIGHBOR", offset = [0, -5], scale = [1, 1, 6, 2]} : (tensor<1x1x4x1xf32>) -> tensor<1x1x12x1xf32>
+// CHECK:  %[[VAL_4:.*]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_5:.*]] = "tosa.transpose"(%[[VAL_3]], %[[VAL_4]]) : (tensor<1x1x12x1xf32>, tensor<4xi64>) -> tensor<1x1x1x12xf32>
+// CHECK:  return %[[VAL_5]] : tensor<1x1x1x12xf32>
 }
 
 // -----
-func.func @test_resize2(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+func.func @test_resize_half_pixel_nearest_round_prefer_ceil(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.Constant"() {value = dense<[1, 1, 3, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
     %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "round_prefer_ceil"} : (tensor<1x1x3x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x3x12xf32>
     return %2 : tensor<1x1x3x12xf32>
+// CHECK-LABEL:  func.func @test_resize_half_pixel_nearest_round_prefer_ceil(
+// CHECK:  %[[VAL_1:.*]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_2:.*]] = "tosa.transpose"(%arg0, %[[VAL_1]]) : (tensor<1x1x3x4xf32>, tensor<4xi64>) -> tensor<1x3x4x1xf32>
+// CHECK:  %[[VAL_3:.*]] = "tosa.resize"(%[[VAL_2]]) {border = [0, 2], mode = "NEAREST_NEIGHBOR", offset = [0, -2], scale = [2, 2, 6, 2]} : (tensor<1x3x4x1xf32>) -> tensor<1x3x12x1xf32>
+// CHECK:  %[[VAL_4:.*]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_5:.*]] = "tosa.transpose"(%[[VAL_3]], %[[VAL_4]]) : (tensor<1x3x12x1xf32>, tensor<4xi64>) -> tensor<1x1x3x12xf32>
+// CHECK:  return %[[VAL_5]] : tensor<1x1x3x12xf32>
 }
 
 // -----
-
-func.func @test_resize(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+func.func @test_resize_align_corners(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
     %0 = "onnx.NoValue"() {value} : () -> none
-    %1 = "onnx.Constant"() {value = dense<[1.000000e+00, 1.000000e+00, 1.000000e+00, 3.000000e+00]> : tensor<4xf32>} : () -> tensor<4xf32>
-    %2 = "onnx.Resize"(%arg0, %0, %1, %0) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "linear", nearest_mode = "floor"} : (tensor<1x1x3x4xf32>, none, tensor<4xf32>, none) -> tensor<1x1x3x12xf32>
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 3, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "align_corners", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "round_prefer_ceil"} : (tensor<1x1x3x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x3x12xf32>
     return %2 : tensor<1x1x3x12xf32>
+// CHECK-LABEL:  func.func @test_resize_align_corners(
+// CHECK:  %[[VAL_1:.*]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_2:.*]] = "tosa.transpose"(%arg0, %[[VAL_1]]) : (tensor<1x1x3x4xf32>, tensor<4xi64>) -> tensor<1x3x4x1xf32>
+// CHECK:  %[[VAL_3:.*]] = "tosa.resize"(%[[VAL_2]]) {border = [0, 0], mode = "NEAREST_NEIGHBOR", offset = [0, 0], scale = [2, 2, 22, 6]} : (tensor<1x3x4x1xf32>) -> tensor<1x3x12x1xf32>
+// CHECK:  %[[VAL_4:.*]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_5:.*]] = "tosa.transpose"(%[[VAL_3]], %[[VAL_4]]) : (tensor<1x3x12x1xf32>, tensor<4xi64>) -> tensor<1x1x3x12xf32>
+// CHECK:  return %[[VAL_5]] : tensor<1x1x3x12xf32>
+}
+
+// -----
+func.func @test_resize_asymmetric(%arg0: tensor<1x1x3x4xf32>) -> tensor<1x1x3x12xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 3, 12]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "asymmetric", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "round_prefer_ceil"} : (tensor<1x1x3x4xf32>, none, none, tensor<4xi64>) -> tensor<1x1x3x12xf32>
+    return %2 : tensor<1x1x3x12xf32>
+// CHECK-LABEL:  func.func @test_resize_asymmetric(
+// CHECK:  %[[VAL_1:.*]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_2:.*]] = "tosa.transpose"(%arg0, %[[VAL_1]]) : (tensor<1x1x3x4xf32>, tensor<4xi64>) -> tensor<1x3x4x1xf32>
+// CHECK:  %[[VAL_3:.*]] = "tosa.resize"(%[[VAL_2]]) {border = [0, 4], mode = "NEAREST_NEIGHBOR", offset = [0, 0], scale = [2, 2, 6, 2]} : (tensor<1x3x4x1xf32>) -> tensor<1x3x12x1xf32>
+// CHECK:  %[[VAL_4:.*]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_5:.*]] = "tosa.transpose"(%[[VAL_3]], %[[VAL_4]]) : (tensor<1x3x12x1xf32>, tensor<4xi64>) -> tensor<1x1x3x12xf32>
+// CHECK:  return %[[VAL_5]] : tensor<1x1x3x12xf32>
+}
+
+// -----
+func.func @test_resize_half_pixel_nearest_floor_downsample(%arg0: tensor<1x1x1x12xf32>) -> tensor<1x1x1x4xf32> {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {value = dense<[1, 1, 1, 4]> : tensor<4xi64>} : () -> tensor<4xi64>
+    %2 = "onnx.Resize"(%arg0, %0, %0, %1) {coordinate_transformation_mode = "half_pixel", cubic_coeff_a = -7.500000e-01 : f32, exclude_outside = 0 : si64, extrapolation_value = 0.000000e+00 : f32, mode = "nearest", nearest_mode = "floor"} : (tensor<1x1x1x12xf32>, none, none, tensor<4xi64>) -> tensor<1x1x1x4xf32>
+    return %2 : tensor<1x1x1x4xf32>
+// CHECK-LABEL:  func.func @test_resize_half_pixel_nearest_floor_downsample(
+// CHECK:  %[[VAL_1:.*]] = "tosa.const"() {value = dense<[0, 2, 3, 1]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_2:.*]] = "tosa.transpose"(%arg0, %[[VAL_1]]) : (tensor<1x1x1x12xf32>, tensor<4xi64>) -> tensor<1x1x12x1xf32>
+// CHECK:  %[[VAL_3:.*]] = "tosa.resize"(%[[VAL_2]]) {border = [0, -3], mode = "NEAREST_NEIGHBOR", offset = [0, 1], scale = [1, 1, 2, 6]} : (tensor<1x1x12x1xf32>) -> tensor<1x1x4x1xf32>
+// CHECK:  %[[VAL_4:.*]] = "tosa.const"() {value = dense<[0, 3, 1, 2]> : tensor<4xi64>} : () -> tensor<4xi64>
+// CHECK:  %[[VAL_5:.*]] = "tosa.transpose"(%[[VAL_3]], %[[VAL_4]]) : (tensor<1x1x4x1xf32>, tensor<4xi64>) -> tensor<1x1x1x4xf32>
+// CHECK:  return %[[VAL_5]] : tensor<1x1x1x4xf32>
 }


### PR DESCRIPTION
The newest opset has even more attributes, but no big refactoring will be needed to support those. We have to adapt to those with the next bump.