### PR TITLE
[onnx-to-tosa] added conversion gather onnx to tosa

### DIFF
--- a/src/Conversion/ONNXToTOSA/CMakeLists.txt
+++ b/src/Conversion/ONNXToTOSA/CMakeLists.txt
@@ -12,6 +12,7 @@ add_onnx_mlir_library(OMONNXToTOSA
   Math/Gemm.cpp
   Math/ReduceMean.cpp
   Tensor/Concat.cpp
+  Tensor/Gather.cpp
   Tensor/Reshape.cpp
   Tensor/Resize.cpp
   Tensor/Constant.cpp

--- a/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
+++ b/src/Conversion/ONNXToTOSA/ConvertONNXToTOSA.cpp
@@ -39,6 +39,8 @@ void populateONNXToTOSAConversionPattern(ConversionTarget &target,
       target, patterns, typeConverter, ctx);
   populateLoweringONNXReshapeOpToTOSAPattern(
       target, patterns, typeConverter, ctx);
+  populateLoweringONNXGatherOpToTOSAPattern(
+      target, patterns, typeConverter, ctx);
   populateLoweringONNXResizeOpToTOSAPattern(
       target, patterns, typeConverter, ctx);
   populateLoweringONNXConstOpToTOSAPattern(

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.cpp
@@ -19,6 +19,7 @@
 #include "src/Conversion/ONNXToTOSA/DialectBuilder.hpp"
 #include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
 #include "src/Dialect/ONNX/ONNXOps.hpp"
+#include <src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp>
 
 using namespace mlir;
 
@@ -122,6 +123,12 @@ Value TosaBuilder::slice(Value &inputConst, llvm::ArrayRef<int64_t> size,
           inputConst, startAttr, sizeAttr);
   return newSliceInput;
 }
+
+llvm::Optional<Value> TosaBuilder::gather(Value resultValue, Value inputValue,
+    Value indicesValue, int32_t batchDims, int32_t axis) {
+  return tosa::convertGatherOp(rewriter(), loc(), resultValue, inputValue,
+      indicesValue, batchDims, axis);
+};
 
 // =============================================================================
 // IndexExpr Builder for Lowering using Shape/TOSA Dialect.

--- a/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
+++ b/src/Conversion/ONNXToTOSA/DialectBuilder.hpp
@@ -41,6 +41,9 @@ struct TosaBuilder : DialectBuilder {
   mlir::Value transpose(mlir::Value &value, llvm::ArrayRef<int32_t> perm);
   mlir::Value slice(mlir::Value &inputConst, llvm::ArrayRef<int64_t> size,
       llvm::ArrayRef<int64_t> start);
+  llvm::Optional<mlir::Value> gather(mlir::Value resultValue,
+      mlir::Value inputValue, mlir::Value indicesValue, int32_t batchDims,
+      int32_t axis);
 
   mlir::Value getConst(
       llvm::ArrayRef<int64_t> vec, llvm::ArrayRef<int64_t> shape);

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.cpp
@@ -4,6 +4,7 @@
 
 //====------ ONNXToTOSACommon.hpp - ONNX dialects to TOSA lowering --------===//
 //
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 // Copyright (c) 2021 Arm Limited.
 // Copyright (c) 2022 Advanced Micro Devices, Inc.
 //

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -33,6 +33,11 @@
 //===----------------------------------------------------------------------===//
 namespace onnx_mlir {
 namespace tosa {
+
+// Lowers Gather operators to a sequence of TOSA ops.
+llvm::Optional<mlir::Value> convertGatherOp(mlir::PatternRewriter &rewriter,
+    mlir::Operation *op, mlir::Value result_value, mlir::Value params_value,
+    mlir::Value indices_value, int32_t batch_dims, int32_t axis);
 // Lowers ReduceMean to a sequence of TOSA ops.
 // Originates from the TorchToTosa conversion
 llvm::Optional<mlir::Value> convertReduceMeanOp(mlir::PatternRewriter &rewriter,
@@ -90,6 +95,8 @@ void populateLoweringONNXMaxPoolSingleOutOpToTOSAPattern(
 void populateLoweringONNXReshapeOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXConcatOpToTOSAPattern(mlir::ConversionTarget &,
+    mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
+void populateLoweringONNXGatherOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);
 void populateLoweringONNXResizeOpToTOSAPattern(mlir::ConversionTarget &,
     mlir::RewritePatternSet &, mlir::TypeConverter &, mlir::MLIRContext *);

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp
@@ -36,8 +36,8 @@ namespace tosa {
 
 // Lowers Gather operators to a sequence of TOSA ops.
 llvm::Optional<mlir::Value> convertGatherOp(mlir::PatternRewriter &rewriter,
-    mlir::Operation *op, mlir::Value result_value, mlir::Value params_value,
-    mlir::Value indices_value, int32_t batch_dims, int32_t axis);
+    mlir::Location loc, mlir::Value resultValue, mlir::Value inputValue,
+    mlir::Value indicesValue, int32_t batchDims, int32_t axis);
 // Lowers ReduceMean to a sequence of TOSA ops.
 // Originates from the TorchToTosa conversion
 llvm::Optional<mlir::Value> convertReduceMeanOp(mlir::PatternRewriter &rewriter,

--- a/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
+++ b/src/Conversion/ONNXToTOSA/Tensor/Gather.cpp
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//===---------------- Gather.cpp - Gather Op ------------------------------===//
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc.
+//
+// =============================================================================
+//
+// This file lowers ONNX GatherOp to TOSA dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSACommon.hpp"
+#include "src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp"
+#include "src/Dialect/ONNX/ONNXOps.hpp"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace mlir;
+
+namespace onnx_mlir {
+
+namespace {
+
+class ONNXGatherLoweringToTOSA : public OpConversionPattern<ONNXGatherOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  using OpAdaptor = typename ONNXGatherOp::Adaptor;
+  LogicalResult matchAndRewrite(ONNXGatherOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+
+    Value input = adaptor.data();
+    Value indices = adaptor.indices();
+    int64_t axis = adaptor.axis();
+    auto inputType = input.getType();
+    if (!onnx_mlir::isRankedShapedType(inputType))
+      return rewriter.notifyMatchFailure(op, "input is not a ranked tensor");
+    int64_t inputRank = onnx_mlir::getRank(inputType);
+
+    // onnx allows values beetween [-r, r-1] where r is the rank
+    if (axis < 0) {
+      axis += inputRank;
+    }
+
+    auto indicesType = indices.getType().cast<ShapedType>();
+    SmallVector<int32_t, 4> newIndicesValues;
+    newIndicesValues.resize(indicesType.getNumElements());
+
+    auto indicesValues = tosa::getValueFromTosaConst<ElementsAttr>(indices);
+
+    ArrayRef<int64_t> inputShape = inputType.cast<ShapedType>().getShape();
+    auto indicesAttrValues = indicesValues.getValues<APInt>();
+    for (const auto [index, value] : llvm::enumerate(indicesAttrValues)) {
+      int64_t numericalValue = value.getSExtValue();
+      if (numericalValue < 0)
+        newIndicesValues[index] = (int32_t)(numericalValue + inputShape[axis]);
+      else
+        newIndicesValues[index] = (int32_t)(numericalValue);
+    }
+
+    llvm::Optional<Value> newIndices = tosa::getConstTensor<int32_t>(
+        rewriter, op, newIndicesValues, indicesType.getShape());
+    if (!newIndices.has_value())
+      return rewriter.notifyMatchFailure(
+          op, "could not determine input indices");
+
+    auto newGather = tosa::convertGatherOp(rewriter, op, op.getResult(), input,
+        newIndices.value(), 0, (int32_t)axis);
+
+    if (!newGather.has_value()) {
+      return failure();
+    }
+    rewriter.replaceOp(op, newGather.value());
+
+    return success();
+  }
+};
+
+} // namespace
+
+void populateLoweringONNXGatherOpToTOSAPattern(ConversionTarget &target,
+    RewritePatternSet &patterns, TypeConverter &typeConverter,
+    MLIRContext *ctx) {
+  patterns.insert<ONNXGatherLoweringToTOSA>(ctx);
+}
+
+} // namespace onnx_mlir

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -20,12 +20,12 @@ func.func @test_gather_axis0(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
 
 // -----
 
-// Test gather along axis 0, first example in ONNX for Gather. Positive indices, so no select.
-func.func @test_gather_axis0neg(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
+// Test negative indices.
+func.func @test_gather_axis0_neg_idx(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
   %indices = "onnx.Constant"() {value = dense<[[0, -1], [1, 2]]> : tensor<2x2xi64>} : () -> tensor<2x2xi64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<2x2x2xf32>
   "func.return"(%0) : (tensor<2x2x2xf32>) -> ()
-// CHECK-LABEL:   func.func @test_gather_axis0neg(
+// CHECK-LABEL:   func.func @test_gather_axis0_neg_idx(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: tensor<3x2xf32>) -> tensor<2x2x2xf32> {
 // CHECK:           %[[VAL_1:.*]] = "tosa.const"() {value = dense<{{\[\[}}0, 2], [1, 2]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
 // CHECK:           %[[VAL_2:.*]] = "tosa.const"() {value = dense<[0, 1]> : tensor<2xi32>} : () -> tensor<2xi32>
@@ -41,7 +41,7 @@ func.func @test_gather_axis0neg(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
 
 // -----
 
-// Test gather along axis 1, second example in ONNX for Gather.
+// Test along axis 1. Transpose should be different.
 func.func @test_gather_axis1(%arg0 : tensor<3x3xf32>) -> tensor<3x1x2xf32> {
   %indices = "onnx.Constant"() {value = dense<[[0, 2]]> : tensor<1x2xi64>} : () -> tensor<1x2xi64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<3x1x2xf32>

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -4,18 +4,17 @@ func.func @test_gather_axis0(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
   %indices = "onnx.Constant"() {value = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>} : () -> tensor<2x2xi64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<2x2x2xf32>
   "func.return"(%0) : (tensor<2x2x2xf32>) -> ()
-
 // CHECK-LABEL:   func.func @test_gather_axis0(
 // CHECK-SAME:                                 %[[VAL_0:.*]]: tensor<3x2xf32>) -> tensor<2x2x2xf32> {
 // CHECK:           %[[VAL_1:.*]] = "tosa.const"() {value = dense<{{\[\[}}0, 1], [1, 2]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() {value = dense<[0, 1]> : tensor<2xi64>} : () -> tensor<2xi64>
-// CHECK:           %[[VAL_3:.*]] = "tosa.transpose"(%[[VAL_0]], %[[VAL_2]]) : (tensor<3x2xf32>, tensor<2xi64>) -> tensor<3x2xf32>
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"() {value = dense<[0, 1]> : tensor<2xi32>} : () -> tensor<2xi32>
+// CHECK:           %[[VAL_3:.*]] = "tosa.transpose"(%[[VAL_0]], %[[VAL_2]]) : (tensor<3x2xf32>, tensor<2xi32>) -> tensor<3x2xf32>
 // CHECK:           %[[VAL_4:.*]] = "tosa.reshape"(%[[VAL_3]]) {new_shape = [1, 3, 2]} : (tensor<3x2xf32>) -> tensor<1x3x2xf32>
 // CHECK:           %[[VAL_5:.*]] = "tosa.reshape"(%[[VAL_1]]) {new_shape = [1, 4]} : (tensor<2x2xi32>) -> tensor<1x4xi32>
 // CHECK:           %[[VAL_6:.*]] = "tosa.gather"(%[[VAL_4]], %[[VAL_5]]) : (tensor<1x3x2xf32>, tensor<1x4xi32>) -> tensor<1x4x2xf32>
 // CHECK:           %[[VAL_7:.*]] = "tosa.reshape"(%[[VAL_6]]) {new_shape = [2, 2, 2]} : (tensor<1x4x2xf32>) -> tensor<2x2x2xf32>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() {value = dense<[0, 1, 2]> : tensor<3xi64>} : () -> tensor<3xi64>
-// CHECK:           %[[VAL_9:.*]] = "tosa.transpose"(%[[VAL_7]], %[[VAL_8]]) : (tensor<2x2x2xf32>, tensor<3xi64>) -> tensor<2x2x2xf32>
+// CHECK:           %[[VAL_8:.*]] = "tosa.const"() {value = dense<[0, 1, 2]> : tensor<3xi32>} : () -> tensor<3xi32>
+// CHECK:           %[[VAL_9:.*]] = "tosa.transpose"(%[[VAL_7]], %[[VAL_8]]) : (tensor<2x2x2xf32>, tensor<3xi32>) -> tensor<2x2x2xf32>
 // CHECK:           return %[[VAL_9]] : tensor<2x2x2xf32>
 }
 
@@ -26,18 +25,17 @@ func.func @test_gather_axis0neg(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
   %indices = "onnx.Constant"() {value = dense<[[0, -1], [1, 2]]> : tensor<2x2xi64>} : () -> tensor<2x2xi64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<2x2x2xf32>
   "func.return"(%0) : (tensor<2x2x2xf32>) -> ()
-
 // CHECK-LABEL:   func.func @test_gather_axis0neg(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: tensor<3x2xf32>) -> tensor<2x2x2xf32> {
 // CHECK:           %[[VAL_1:.*]] = "tosa.const"() {value = dense<{{\[\[}}0, 2], [1, 2]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() {value = dense<[0, 1]> : tensor<2xi64>} : () -> tensor<2xi64>
-// CHECK:           %[[VAL_3:.*]] = "tosa.transpose"(%[[VAL_0]], %[[VAL_2]]) : (tensor<3x2xf32>, tensor<2xi64>) -> tensor<3x2xf32>
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"() {value = dense<[0, 1]> : tensor<2xi32>} : () -> tensor<2xi32>
+// CHECK:           %[[VAL_3:.*]] = "tosa.transpose"(%[[VAL_0]], %[[VAL_2]]) : (tensor<3x2xf32>, tensor<2xi32>) -> tensor<3x2xf32>
 // CHECK:           %[[VAL_4:.*]] = "tosa.reshape"(%[[VAL_3]]) {new_shape = [1, 3, 2]} : (tensor<3x2xf32>) -> tensor<1x3x2xf32>
 // CHECK:           %[[VAL_5:.*]] = "tosa.reshape"(%[[VAL_1]]) {new_shape = [1, 4]} : (tensor<2x2xi32>) -> tensor<1x4xi32>
 // CHECK:           %[[VAL_6:.*]] = "tosa.gather"(%[[VAL_4]], %[[VAL_5]]) : (tensor<1x3x2xf32>, tensor<1x4xi32>) -> tensor<1x4x2xf32>
 // CHECK:           %[[VAL_7:.*]] = "tosa.reshape"(%[[VAL_6]]) {new_shape = [2, 2, 2]} : (tensor<1x4x2xf32>) -> tensor<2x2x2xf32>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() {value = dense<[0, 1, 2]> : tensor<3xi64>} : () -> tensor<3xi64>
-// CHECK:           %[[VAL_9:.*]] = "tosa.transpose"(%[[VAL_7]], %[[VAL_8]]) : (tensor<2x2x2xf32>, tensor<3xi64>) -> tensor<2x2x2xf32>
+// CHECK:           %[[VAL_8:.*]] = "tosa.const"() {value = dense<[0, 1, 2]> : tensor<3xi32>} : () -> tensor<3xi32>
+// CHECK:           %[[VAL_9:.*]] = "tosa.transpose"(%[[VAL_7]], %[[VAL_8]]) : (tensor<2x2x2xf32>, tensor<3xi32>) -> tensor<2x2x2xf32>
 // CHECK:           return %[[VAL_9]] : tensor<2x2x2xf32>
 }
 
@@ -48,17 +46,16 @@ func.func @test_gather_axis1(%arg0 : tensor<3x3xf32>) -> tensor<3x1x2xf32> {
   %indices = "onnx.Constant"() {value = dense<[[0, 2]]> : tensor<1x2xi64>} : () -> tensor<1x2xi64>
   %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<3x1x2xf32>
   "func.return"(%0) : (tensor<3x1x2xf32>) -> ()
-
 // CHECK-LABEL:   func.func @test_gather_axis1(
 // CHECK-SAME:                                 %[[VAL_0:.*]]: tensor<3x3xf32>) -> tensor<3x1x2xf32> {
 // CHECK:           %[[VAL_1:.*]] = "tosa.const"() {value = dense<{{\[\[}}0, 2]]> : tensor<1x2xi32>} : () -> tensor<1x2xi32>
-// CHECK:           %[[VAL_2:.*]] = "tosa.const"() {value = dense<[1, 0]> : tensor<2xi64>} : () -> tensor<2xi64>
-// CHECK:           %[[VAL_3:.*]] = "tosa.transpose"(%[[VAL_0]], %[[VAL_2]]) : (tensor<3x3xf32>, tensor<2xi64>) -> tensor<3x3xf32>
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"() {value = dense<[1, 0]> : tensor<2xi32>} : () -> tensor<2xi32>
+// CHECK:           %[[VAL_3:.*]] = "tosa.transpose"(%[[VAL_0]], %[[VAL_2]]) : (tensor<3x3xf32>, tensor<2xi32>) -> tensor<3x3xf32>
 // CHECK:           %[[VAL_4:.*]] = "tosa.reshape"(%[[VAL_3]]) {new_shape = [1, 3, 3]} : (tensor<3x3xf32>) -> tensor<1x3x3xf32>
 // CHECK:           %[[VAL_5:.*]] = "tosa.reshape"(%[[VAL_1]]) {new_shape = [1, 2]} : (tensor<1x2xi32>) -> tensor<1x2xi32>
 // CHECK:           %[[VAL_6:.*]] = "tosa.gather"(%[[VAL_4]], %[[VAL_5]]) : (tensor<1x3x3xf32>, tensor<1x2xi32>) -> tensor<1x2x3xf32>
 // CHECK:           %[[VAL_7:.*]] = "tosa.reshape"(%[[VAL_6]]) {new_shape = [1, 2, 3]} : (tensor<1x2x3xf32>) -> tensor<1x2x3xf32>
-// CHECK:           %[[VAL_8:.*]] = "tosa.const"() {value = dense<[2, 0, 1]> : tensor<3xi64>} : () -> tensor<3xi64>
-// CHECK:           %[[VAL_9:.*]] = "tosa.transpose"(%[[VAL_7]], %[[VAL_8]]) : (tensor<1x2x3xf32>, tensor<3xi64>) -> tensor<3x1x2xf32>
+// CHECK:           %[[VAL_8:.*]] = "tosa.const"() {value = dense<[2, 0, 1]> : tensor<3xi32>} : () -> tensor<3xi32>
+// CHECK:           %[[VAL_9:.*]] = "tosa.transpose"(%[[VAL_7]], %[[VAL_8]]) : (tensor<1x2x3xf32>, tensor<3xi32>) -> tensor<3x1x2xf32>
 // CHECK:           return %[[VAL_9]] : tensor<3x1x2xf32>
 }

--- a/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/Tensor/Gather.mlir
@@ -1,0 +1,64 @@
+// RUN: onnx-mlir-opt --convert-onnx-to-tosa -cse %s -split-input-file | FileCheck %s
+
+func.func @test_gather_axis0(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
+  %indices = "onnx.Constant"() {value = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>} : () -> tensor<2x2xi64>
+  %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<2x2x2xf32>
+  "func.return"(%0) : (tensor<2x2x2xf32>) -> ()
+
+// CHECK-LABEL:   func.func @test_gather_axis0(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: tensor<3x2xf32>) -> tensor<2x2x2xf32> {
+// CHECK:           %[[VAL_1:.*]] = "tosa.const"() {value = dense<{{\[\[}}0, 1], [1, 2]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"() {value = dense<[0, 1]> : tensor<2xi64>} : () -> tensor<2xi64>
+// CHECK:           %[[VAL_3:.*]] = "tosa.transpose"(%[[VAL_0]], %[[VAL_2]]) : (tensor<3x2xf32>, tensor<2xi64>) -> tensor<3x2xf32>
+// CHECK:           %[[VAL_4:.*]] = "tosa.reshape"(%[[VAL_3]]) {new_shape = [1, 3, 2]} : (tensor<3x2xf32>) -> tensor<1x3x2xf32>
+// CHECK:           %[[VAL_5:.*]] = "tosa.reshape"(%[[VAL_1]]) {new_shape = [1, 4]} : (tensor<2x2xi32>) -> tensor<1x4xi32>
+// CHECK:           %[[VAL_6:.*]] = "tosa.gather"(%[[VAL_4]], %[[VAL_5]]) : (tensor<1x3x2xf32>, tensor<1x4xi32>) -> tensor<1x4x2xf32>
+// CHECK:           %[[VAL_7:.*]] = "tosa.reshape"(%[[VAL_6]]) {new_shape = [2, 2, 2]} : (tensor<1x4x2xf32>) -> tensor<2x2x2xf32>
+// CHECK:           %[[VAL_8:.*]] = "tosa.const"() {value = dense<[0, 1, 2]> : tensor<3xi64>} : () -> tensor<3xi64>
+// CHECK:           %[[VAL_9:.*]] = "tosa.transpose"(%[[VAL_7]], %[[VAL_8]]) : (tensor<2x2x2xf32>, tensor<3xi64>) -> tensor<2x2x2xf32>
+// CHECK:           return %[[VAL_9]] : tensor<2x2x2xf32>
+}
+
+// -----
+
+// Test gather along axis 0, first example in ONNX for Gather. Positive indices, so no select.
+func.func @test_gather_axis0neg(%arg0 : tensor<3x2xf32>) -> tensor<2x2x2xf32> {
+  %indices = "onnx.Constant"() {value = dense<[[0, -1], [1, 2]]> : tensor<2x2xi64>} : () -> tensor<2x2xi64>
+  %0 = "onnx.Gather"(%arg0, %indices) {axis = 0 : si64} : (tensor<3x2xf32>, tensor<2x2xi64>) -> tensor<2x2x2xf32>
+  "func.return"(%0) : (tensor<2x2x2xf32>) -> ()
+
+// CHECK-LABEL:   func.func @test_gather_axis0neg(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: tensor<3x2xf32>) -> tensor<2x2x2xf32> {
+// CHECK:           %[[VAL_1:.*]] = "tosa.const"() {value = dense<{{\[\[}}0, 2], [1, 2]]> : tensor<2x2xi32>} : () -> tensor<2x2xi32>
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"() {value = dense<[0, 1]> : tensor<2xi64>} : () -> tensor<2xi64>
+// CHECK:           %[[VAL_3:.*]] = "tosa.transpose"(%[[VAL_0]], %[[VAL_2]]) : (tensor<3x2xf32>, tensor<2xi64>) -> tensor<3x2xf32>
+// CHECK:           %[[VAL_4:.*]] = "tosa.reshape"(%[[VAL_3]]) {new_shape = [1, 3, 2]} : (tensor<3x2xf32>) -> tensor<1x3x2xf32>
+// CHECK:           %[[VAL_5:.*]] = "tosa.reshape"(%[[VAL_1]]) {new_shape = [1, 4]} : (tensor<2x2xi32>) -> tensor<1x4xi32>
+// CHECK:           %[[VAL_6:.*]] = "tosa.gather"(%[[VAL_4]], %[[VAL_5]]) : (tensor<1x3x2xf32>, tensor<1x4xi32>) -> tensor<1x4x2xf32>
+// CHECK:           %[[VAL_7:.*]] = "tosa.reshape"(%[[VAL_6]]) {new_shape = [2, 2, 2]} : (tensor<1x4x2xf32>) -> tensor<2x2x2xf32>
+// CHECK:           %[[VAL_8:.*]] = "tosa.const"() {value = dense<[0, 1, 2]> : tensor<3xi64>} : () -> tensor<3xi64>
+// CHECK:           %[[VAL_9:.*]] = "tosa.transpose"(%[[VAL_7]], %[[VAL_8]]) : (tensor<2x2x2xf32>, tensor<3xi64>) -> tensor<2x2x2xf32>
+// CHECK:           return %[[VAL_9]] : tensor<2x2x2xf32>
+}
+
+// -----
+
+// Test gather along axis 1, second example in ONNX for Gather.
+func.func @test_gather_axis1(%arg0 : tensor<3x3xf32>) -> tensor<3x1x2xf32> {
+  %indices = "onnx.Constant"() {value = dense<[[0, 2]]> : tensor<1x2xi64>} : () -> tensor<1x2xi64>
+  %0 = "onnx.Gather"(%arg0, %indices) {axis = 1 : si64} : (tensor<3x3xf32>, tensor<1x2xi64>) -> tensor<3x1x2xf32>
+  "func.return"(%0) : (tensor<3x1x2xf32>) -> ()
+
+// CHECK-LABEL:   func.func @test_gather_axis1(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: tensor<3x3xf32>) -> tensor<3x1x2xf32> {
+// CHECK:           %[[VAL_1:.*]] = "tosa.const"() {value = dense<{{\[\[}}0, 2]]> : tensor<1x2xi32>} : () -> tensor<1x2xi32>
+// CHECK:           %[[VAL_2:.*]] = "tosa.const"() {value = dense<[1, 0]> : tensor<2xi64>} : () -> tensor<2xi64>
+// CHECK:           %[[VAL_3:.*]] = "tosa.transpose"(%[[VAL_0]], %[[VAL_2]]) : (tensor<3x3xf32>, tensor<2xi64>) -> tensor<3x3xf32>
+// CHECK:           %[[VAL_4:.*]] = "tosa.reshape"(%[[VAL_3]]) {new_shape = [1, 3, 3]} : (tensor<3x3xf32>) -> tensor<1x3x3xf32>
+// CHECK:           %[[VAL_5:.*]] = "tosa.reshape"(%[[VAL_1]]) {new_shape = [1, 2]} : (tensor<1x2xi32>) -> tensor<1x2xi32>
+// CHECK:           %[[VAL_6:.*]] = "tosa.gather"(%[[VAL_4]], %[[VAL_5]]) : (tensor<1x3x3xf32>, tensor<1x2xi32>) -> tensor<1x2x3xf32>
+// CHECK:           %[[VAL_7:.*]] = "tosa.reshape"(%[[VAL_6]]) {new_shape = [1, 2, 3]} : (tensor<1x2x3xf32>) -> tensor<1x2x3xf32>
+// CHECK:           %[[VAL_8:.*]] = "tosa.const"() {value = dense<[2, 0, 1]> : tensor<3xi64>} : () -> tensor<3xi64>
+// CHECK:           %[[VAL_9:.*]] = "tosa.transpose"(%[[VAL_7]], %[[VAL_8]]) : (tensor<1x2x3xf32>, tensor<3xi64>) -> tensor<3x1x2xf32>
+// CHECK:           return %[[VAL_9]] : tensor<3x1x2xf32>
+}


### PR DESCRIPTION
Most of the code is from [TensorFlow](https://github.com/tensorflow/tensorflow/blob/57d2fe48f550bf23d3b87fa396a587e2d2052ed6/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc#L3719), but I refactored it quite a lot.