### PR TITLE
Fix Reciprocal OP argument on QuantizeLinear lowering 

### DIFF
--- a/src/Conversion/ONNXToTOSA/NN/QuantizeLinear.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/QuantizeLinear.cpp
@@ -67,8 +67,8 @@ public:
     
     // Quantization formula is ((x / y_scale) + y_zero_point)
     // Replace the division by a reciprocal followed by a mul
-    Value recOp = tosa::CreateOpAndInfer<mlir::tosa::ReciprocalOp>(rewriter, loc, xType, x).getResult();
-    Value mulOp = tosa::CreateOpAndInfer<mlir::tosa::MulOp>(rewriter, loc, xType, recOp, scaleFactorConst, 0).getResult();
+    Value recOp = tosa::CreateOpAndInfer<mlir::tosa::ReciprocalOp>(rewriter, loc, scaleFactorConst.getType(), scaleFactorConst).getResult();
+    Value mulOp = tosa::CreateOpAndInfer<mlir::tosa::MulOp>(rewriter, loc, xType, x, recOp, 0).getResult();
     // Cast into the result type
     Value castOp = tosa::CreateOpAndInfer<mlir::tosa::CastOp>(rewriter, loc, resultType, mulOp).getResult();
     Value addOp = tosa::CreateOpAndInfer<mlir::tosa::AddOp>(rewriter, loc, resultType, castOp, zpConst).getResult();

--- a/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
+++ b/test/mlir/conversion/onnx_to_tosa/NN/QuantizeLinear.mlir
@@ -9,8 +9,8 @@ func.func @test_quantizeLinear(%arg0 : tensor<32x3x224x224xf32>) -> tensor<32x3x
 // CHECK-LABEL:  @test_quantizeLinear(%arg0: tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi8>
 // CHECK-DAG:    %[[SCALE:.*]] = "tosa.const"() {value = dense<3.125000e-02> : tensor<1x1x1x1xf32>} : () -> tensor<1x1x1x1xf32>
 // CHECK-DAG:    %[[ZP:.*]] = "tosa.const"() {value = dense<0> : tensor<1x1x1x1xi8>} : () -> tensor<1x1x1x1xi8>
-// CHECK-DAG:    %[[REC:.*]] = "tosa.reciprocal"(%arg0) : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xf32>
-// CHECK-DAG:    %[[MUL:.*]] = "tosa.mul"(%[[REC]], %[[SCALE]]) {shift = 0 : i32} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
+// CHECK-DAG:    %[[REC:.*]] = "tosa.reciprocal"(%[[SCALE]]) : (tensor<1x1x1x1xf32>) -> tensor<1x1x1x1xf32>
+// CHECK-DAG:    %[[MUL:.*]] = "tosa.mul"(%arg0, %[[REC]]) {shift = 0 : i32} : (tensor<32x3x224x224xf32>, tensor<1x1x1x1xf32>) -> tensor<32x3x224x224xf32>
 // CHECK-DAG:    %[[CAST:.*]] = "tosa.cast"(%[[MUL]]) : (tensor<32x3x224x224xf32>) -> tensor<32x3x224x224xi8>
 // CHECK-DAG:    %[[ADD:.*]] = "tosa.add"(%[[CAST]], %[[ZP]]) : (tensor<32x3x224x224xi8>, tensor<1x1x1x1xi8>) -> tensor<32x3x224x224xi8>
 // CHECK-DAG:    return %[[ADD]] : tensor<32x3x224x224xi8>


### PR DESCRIPTION
There is an issue with the current lowering where the reciprocal is applied on the input and not on the scale, making it a (scale/input) and not (input/scale).
This PR brings back the normal arguments. 