### PR TITLE
Add support for count_include_pad in average_pool operation.

### DIFF
--- a/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
+++ b/src/Conversion/ONNXToTOSA/NN/AveragePool.cpp
@@ -28,6 +28,45 @@ namespace onnx_mlir {
 
 namespace {
 
+void handleIncludePadAttr(
+    ConversionPatternRewriter &rewriter, Operation *op, Value input) {
+  mlir::Location loc = op->getLoc();
+
+  // Get shape.
+  IndexExprBuilderForTosa createTosaIE(rewriter, loc);
+  ONNXGenericPoolOpShapeHelper<ONNXAveragePoolOp> shapeHelper(
+      op, {}, &createTosaIE);
+  shapeHelper.computeShapeAndAssertOnFailure();
+
+  // Get onnx padding. Ignore ceil mode since it is handled later.
+  mlir::ArrayAttr pads = tosa::createOrderedPadAttr(rewriter,
+      input.getType().cast<mlir::TensorType>().getShape(), shapeHelper,
+      /*ceilMode*/ 0, {0, 1, 2, 3});
+
+  // Build an array with padding.
+  llvm::SmallVector<int64_t, 4> intValues;
+  llvm::for_each(pads.getAsRange<IntegerAttr>(),
+      [&](mlir::IntegerAttr n) { intValues.push_back(n.getInt()); });
+
+  // Create Padding and ConstPad tosa::ConstOp's
+  TosaBuilder tosaBuilder(rewriter, loc);
+  Value padding = tosa::buildOnnxToTosaPaddingConstOp(
+      rewriter, intValues, loc, {0, 0, 0, 0}, {});
+  auto constTosaTensor = tosaBuilder.getConst(0.0);
+
+  auto inputType = input.getType().cast<mlir::TensorType>();
+  auto padOp = tosa::CreateOpAndInfer<mlir::tosa::PadOp>(rewriter, loc,
+      mlir::RankedTensorType::get(
+          llvm::SmallVector<int64_t, 4>(inputType.getShape().size(), -1),
+          inputType.getElementType()),
+      input, padding, constTosaTensor);
+
+  // In-place update of AveragePool by setting operand to PadOp
+  // and pads attribute to {0, 0, 0, 0}.
+  op->setOperand(0, padOp);
+  op->setAttr("pads", rewriter.getI32ArrayAttr({0, 0, 0, 0}));
+}
+
 class ONNXAveragePoolOpLoweringToTOSA : public ConversionPattern {
 public:
   ONNXAveragePoolOpLoweringToTOSA(MLIRContext *ctx)
@@ -40,10 +79,12 @@ public:
 
     const int64_t includePad = adaptor.count_include_pad();
 
-    // The attribute include_pad is unsupported
     if (includePad != 0) {
-      return rewriter.notifyMatchFailure(
-          averagePoolOp, "count_include_pad must be 0");
+      // When attribute include_pad is set, create a tosa::PadOp before lowering
+      // AveragePool to TOSA. We use ONNX format for it so that the AveragePool
+      // lowering still generates transposes between ONNX and TOSA formats, and
+      // implementation doesn't diverge much.
+      handleIncludePadAttr(rewriter, op, adaptor.X());
     }
 
     llvm::Optional<Value> newAveragePoolOp =

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -104,5 +104,33 @@ Value buildRescaleToInt32(PatternRewriter &rewriter, Operation *op,
       input_zp, 0, false, true);
 }
 
+mlir::Value buildOnnxToTosaPaddingConstOp(mlir::PatternRewriter &rewriter,
+    llvm::ArrayRef<int64_t> onnxPads, mlir::Location loc,
+    const std::initializer_list<int64_t> &initialVals,
+    const std::initializer_list<int64_t> &lastVals) {
+
+  // Create a new pad vec in the right format
+  // ONNX : [b1, b2, b3, b4, e1, e2, e3, e4]
+  // TOSA :[[b1, e1], [b2, e2], [b3, e3], [b4, e4]]
+
+  // Adds any initial or last vals, not included in onnxPads.
+  llvm::SmallVector<int64_t, 8> tosaPads{initialVals};
+
+  const unsigned int dimSize = onnxPads.size() / 2;
+  for (unsigned int i = 0; i < dimSize; i++) {
+    tosaPads.push_back(onnxPads[i]);
+    tosaPads.push_back(onnxPads[i + dimSize]);
+  }
+  tosaPads.insert(tosaPads.end(), lastVals.begin(), lastVals.end());
+
+  const unsigned int numberOfDims = tosaPads.size() / 2;
+  mlir::DenseElementsAttr paddingAttr = mlir::DenseIntElementsAttr::get(
+      mlir::RankedTensorType::get({numberOfDims, 2}, rewriter.getI64Type()),
+      tosaPads);
+
+  return rewriter.create<mlir::tosa::ConstOp>(
+      loc, paddingAttr.getType(), paddingAttr);
+}
+
 } // namespace tosa
 } // namespace onnx_mlir

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.cpp
@@ -123,13 +123,10 @@ mlir::Value buildOnnxToTosaPaddingConstOp(mlir::PatternRewriter &rewriter,
   }
   tosaPads.insert(tosaPads.end(), lastVals.begin(), lastVals.end());
 
+  // TOSA format groups dimensions by 2.
   const unsigned int numberOfDims = tosaPads.size() / 2;
-  mlir::DenseElementsAttr paddingAttr = mlir::DenseIntElementsAttr::get(
-      mlir::RankedTensorType::get({numberOfDims, 2}, rewriter.getI64Type()),
-      tosaPads);
-
-  return rewriter.create<mlir::tosa::ConstOp>(
-      loc, paddingAttr.getType(), paddingAttr);
+  TosaBuilder tosaBuilder(rewriter, loc);
+  return tosaBuilder.getConst(tosaPads, {numberOfDims, 2});
 }
 
 } // namespace tosa

--- a/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
+++ b/src/Conversion/ONNXToTOSA/ONNXToTOSALegalizeUtils.hpp
@@ -102,6 +102,12 @@ mlir::Value buildRescaleToInt32(mlir::PatternRewriter &rewriter,
     mlir::Operation *op, mlir::Value input_val, double input_scale,
     int64_t input_zp);
 
+// Create a padding tosa::ConstOp from ONNX to Tosa format.
+mlir::Value buildOnnxToTosaPaddingConstOp(mlir::PatternRewriter &rewriter,
+    llvm::ArrayRef<int64_t> onnxPads, mlir::Location loc,
+    const std::initializer_list<int64_t> &initialVals = {},
+    const std::initializer_list<int64_t> &lastVals = {});
+
 } // namespace tosa
 } // namespace onnx_mlir
 


### PR DESCRIPTION
AveragePool operations had no support for `count_include_pad` attribute. This PR handles it by lowering the AvgPool to `Pad+AvgPool` operations. Pad is done in ONNX format to reuse transposes that are introduced during regular AvgPool lowering.